### PR TITLE
refact : 프론트엔드 refresh token 저장 방식 변경

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import axios from 'axios';
 import { reissue } from './apis/reissue';
 
 export default function App() {
-  const { tokens, setTokens, logout } = userStore();
+  const { token, setToken, logout } = userStore();
   const { VITE_BASE_URL } = import.meta.env;
 
   axios.defaults.baseURL = VITE_BASE_URL;
@@ -22,9 +22,8 @@ export default function App() {
         try {
           refresh = true;
           const data = await reissue();
-          setTokens({
+          setToken({
             access_token: data!.data.access_token,
-            refresh_token: data!.data.refresh_token,
           });
           axios.defaults.headers.common['Authorization'] =
             data!.data.access_token;
@@ -44,8 +43,8 @@ export default function App() {
   const queryClient = getClient();
   const elem = useRoutes(routes);
   useEffect(() => {
-    if (tokens) {
-      setInterceptor(tokens.access_token);
+    if (token) {
+      setInterceptor(token.access_token);
     }
   }, []);
   return (

--- a/src/apis/login.ts
+++ b/src/apis/login.ts
@@ -2,7 +2,9 @@ import axios, { AxiosError } from 'axios';
 
 export const LoginAPI = async (form: LoginForm) => {
   try {
-    const { data } = await axios.post<LoginSuccess>('/users/sign-in', form);
+    const { data } = await axios.post<LoginSuccess>('/users/sign-in', form, {
+      withCredentials: true,
+    });
     axios.defaults.headers.common['Authorization'] = data.data.access_token;
     return data;
   } catch (err) {
@@ -13,7 +15,7 @@ export const LoginAPI = async (form: LoginForm) => {
 export type LoginSuccess = {
   code: string;
   message: string;
-  data: Tokens;
+  data: Token;
 };
 
 export type LoginError = {

--- a/src/apis/reissue.ts
+++ b/src/apis/reissue.ts
@@ -2,12 +2,14 @@ import axios from 'axios';
 
 export const reissue = async () => {
   try {
-    const { data } = await axios.post<ReissueResponse>('/users/reissue', {
-      access_token: JSON.parse(localStorage.getItem('user')!).state.tokens
-        .access_token,
-      refresh_token: JSON.parse(localStorage.getItem('user')!).state.tokens
-        .refresh_token,
-    });
+    const { data } = await axios.post<ReissueResponse>(
+      '/users/reissue',
+      {
+        access_token: JSON.parse(localStorage.getItem('user')!).state.tokens
+          .access_token,
+      },
+      { withCredentials: true },
+    );
     return data;
   } catch (e) {
     return;

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -10,7 +10,7 @@ import { menuToggleStore } from '@/store/menuToggleStore';
 import useWindowSize from '@/hooks/useWindowSize';
 
 export default function Navbar() {
-  const { tokens } = userStore();
+  const { token } = userStore();
   const { setToggle } = menuToggleStore();
   const location = useLocation();
   const underlineRef = useRef<HTMLDivElement>(null);
@@ -79,7 +79,7 @@ export default function Navbar() {
           >
             커뮤니티
           </Link>
-          {tokens ? <AfterLogin /> : <BeforeLogin />}
+          {token ? <AfterLogin /> : <BeforeLogin />}
         </div>
       </div>
     );

--- a/src/components/ToggleMenu/index.tsx
+++ b/src/components/ToggleMenu/index.tsx
@@ -9,7 +9,7 @@ import { motion } from 'framer-motion';
 import { toggleVariants } from '@/constants/variants';
 
 export default function ToggleMenu() {
-  const { tokens } = userStore();
+  const { token } = userStore();
   const { setToggle } = menuToggleStore();
   const onToggleMenu = (e: React.MouseEvent<HTMLDivElement>) => {
     if (e.currentTarget.id === 'overlay') {
@@ -43,7 +43,7 @@ export default function ToggleMenu() {
         <Link to="/introduce">오도이촌 소개</Link>
         <Link to="/trade">빈집거래</Link>
         <Link to="/community">커뮤니티</Link>
-        {tokens ? <AfterLogin /> : <BeforeLogin />}
+        {token ? <AfterLogin /> : <BeforeLogin />}
       </div>
     </motion.div>
   );

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -8,7 +8,7 @@ import { LoginAPI, LoginForm } from '@/apis/login';
 import userStore from '@/store/userStore';
 
 export default function LoginPage() {
-  const { tokens, setTokens } = userStore();
+  const { token, setToken } = userStore();
   const navigate = useNavigate();
   const [id, handleId, setId] = useInput('');
   const [password, handlePassword, setPassword] = useInput('');
@@ -25,11 +25,10 @@ export default function LoginPage() {
     };
     const response = await LoginAPI(form);
     if (response?.code === 'SUCCESS') {
-      const tokens: Tokens = {
+      const token: Token = {
         access_token: response?.data.access_token,
-        refresh_token: response?.data.refresh_token,
       };
-      setTokens(tokens);
+      setToken(token);
       navigate('/');
     }
   };
@@ -44,7 +43,7 @@ export default function LoginPage() {
       handleLogin();
     }
   };
-  if (tokens) {
+  if (token) {
     return <Navigate to="/" />;
   }
   return (

--- a/src/pages/Mypage/index.tsx
+++ b/src/pages/Mypage/index.tsx
@@ -5,9 +5,9 @@ import { motion } from 'framer-motion';
 import { Navigate } from 'react-router-dom';
 
 export default function MyPage() {
-  const { tokens } = userStore();
+  const { token } = userStore();
 
-  if (!tokens) return <Navigate to="/login" />;
+  if (!token) return <Navigate to="/login" />;
   return (
     <motion.div variants={opacityVariants} initial="initial" animate="mount">
       <Preparation />

--- a/src/pages/SignUp/index.tsx
+++ b/src/pages/SignUp/index.tsx
@@ -85,7 +85,7 @@ export default function SignUpPage() {
     },
   });
   const navigate = useNavigate();
-  const { tokens } = userStore();
+  const { token } = userStore();
   const [toggle, setToggle] = useState(false); // 약관 토글
   const [eyeState, setEyeState] = useState(false);
   const [eyeCheckState, setEyeCheckState] = useState(false);
@@ -208,7 +208,7 @@ export default function SignUpPage() {
     setPhoneSMSMessage('전화번호 인증을 해주세요.');
   }, [watch('phone_num')]);
 
-  if (tokens) {
+  if (token) {
     return <Navigate to="/" />;
   }
   return (

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -3,9 +3,9 @@ import { persist, PersistOptions } from 'zustand/middleware';
 
 type UserStore = {
   user: User | null;
-  tokens: Tokens | null;
+  token: Token | null;
   setUser: (user: User | null) => void;
-  setTokens: (tokens: Tokens | null) => void;
+  setToken: (token: Token | null) => void;
   logout: () => void;
 };
 type UserPersist = (
@@ -17,11 +17,11 @@ const userStore = create<UserStore>(
   (persist as UserPersist)(
     (set) => ({
       user: null,
-      tokens: null,
-      setTokens: (tokens: Tokens | null) => set({ tokens }),
+      token: null,
+      setToken: (token: Token | null) => set({ token }),
       setUser: (user: User | null) => set({ user }),
       logout: () => {
-        set({ tokens: null });
+        set({ token: null });
         set({ user: null });
       },
     }),

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -10,8 +10,7 @@ declare global {
     age: string;
   };
 
-  type Tokens = {
+  type Token = {
     access_token: string;
-    refresh_token: string;
   };
 }


### PR DESCRIPTION
## 추가한 기능 설명

refresh token 저장 방식 변경에 따른 프론트엔드 코드 수정
- Token 타입 변경 (refresh token 삭제)
- 로그인 api header에 withCredentials 추가
- reissue api 코드 수정 (refresh token 삭제)


<br>

## check list

- [ ] issue number를 브랜치 앞에 추가 하였는가?
- [ ] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
