### PR TITLE
hotfix : 게시글 리스트 조회 API 변동에 따른 운영환경 API 호출 코드 수정 핫픽스

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist-ssr
 *.sw?
 
 .env
+.eslintcache

--- a/src/components/BoardComponents/Like/index.tsx
+++ b/src/components/BoardComponents/Like/index.tsx
@@ -15,8 +15,12 @@ type LikeProps = {
 export default function Like({ boardId, loveCount, intro }: LikeProps) {
   const { user } = userStore();
   const queryClient = useQueryClient();
-  const { data } = useQuery<GetLikeResponse>([QueryKeys.LIKE], () =>
-    restFetcher({ method: 'GET', path: `/loves/${boardId}` }),
+  const { data: isLove } = useQuery<GetLikeResponse>(
+    [QueryKeys.LIKE],
+    () => restFetcher({ method: 'GET', path: `/loves/${boardId}` }),
+    {
+      enabled: !!user,
+    },
   );
   const { mutate: clickLove } = useMutation(
     () => restFetcher({ method: 'PUT', path: `/loves/${boardId}` }),
@@ -56,7 +60,7 @@ export default function Like({ boardId, loveCount, intro }: LikeProps) {
       },
     },
   );
-  const { mutate: cancleLove } = useMutation(
+  const { mutate: cancelLove } = useMutation(
     () => restFetcher({ method: 'DELETE', path: `/loves/${boardId}` }),
     {
       onMutate: async () => {
@@ -99,12 +103,12 @@ export default function Like({ boardId, loveCount, intro }: LikeProps) {
       alert('로그인 후 이용 가능합니다.');
       return;
     }
-    data?.data ? cancleLove() : clickLove();
+    isLove?.data ? cancelLove() : clickLove();
   };
   return (
     <div className={styles.wrapper}>
       <img
-        src={data?.data ? love : notLove}
+        src={isLove?.data ? love : notLove}
         alt="like"
         onClick={onClickButton}
       />

--- a/src/pages/Introduce/index.tsx
+++ b/src/pages/Introduce/index.tsx
@@ -28,7 +28,7 @@ export default function IntroducePage() {
       restFetcher({
         method: 'GET',
         path: 'boards',
-        params: { category: 'INTRO' },
+        params: { prefix: 'INTRO' },
       }),
     {
       onSuccess: (data) => {

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -31,7 +31,7 @@ export default function MainPage() {
       restFetcher({
         method: 'GET',
         path: 'boards',
-        params: { category: 'INTRO' },
+        params: { prefix: 'INTRO' },
       }),
     {
       onSuccess: (data) => {


### PR DESCRIPTION
## 🤔 수정 내용

게시글 리스트 조회 API 명세 변경에 따른 메인페이지, 오도이촌 소개 페이지 게시글 리스트 조회 API 호출 코드 수정
- /api/v1/boards의 params부분을 category -> prefix로 수정

로그인 하지 않은 유저 좋아요 여부 조회 버그 수정
- 유저의 좋아요 여부 확인 API 호출 부분에 `enabled: !!user`를 추가하여 로그인 하지 않았을 시 API 호출 자체를 하지 않도록 수정
<br>

## 🚩 코드 수정 위치

- src/pages/Introduce/index.tsx
- src/pages/Main/index.tsx
- .gitignore (.eslintcache 파일 추가)
<br>

