### PR TITLE
Design/#86 배너 이미지 크기 수정, 게시글 폰트 사이즈 수정

### DIFF
--- a/src/pages/Community/Detail/styles.module.scss
+++ b/src/pages/Community/Detail/styles.module.scss
@@ -46,24 +46,24 @@
 
 .content {
   & h1 {
-    font-size: 2.5rem;
-    line-height: 3.5rem;
-    margin-bottom: 1rem;
-    font-family: 'NanumSquareAcB';
-  }
-  & h2 {
     font-size: 2rem;
     line-height: 3rem;
     margin-bottom: 1rem;
     font-family: 'NanumSquareAcB';
   }
-  & h5 {
-    font-size: 1.2rem;
-    line-height: 2.2rem;
-  }
-  & p {
+  & h2 {
     font-size: 1.5rem;
     line-height: 2.5rem;
+    margin-bottom: 1rem;
+    font-family: 'NanumSquareAcB';
+  }
+  & h5 {
+    font-size: 1rem;
+    line-height: 2rem;
+  }
+  & p {
+    font-size: 1.3rem;
+    line-height: 2.3rem;
   }
   & strong {
     font-family: 'NanumSquareAcB';

--- a/src/pages/Introduce/Board/styles.module.scss
+++ b/src/pages/Introduce/Board/styles.module.scss
@@ -4,11 +4,11 @@
 }
 .banner {
   width: 100%;
-  height: 60rem;
+  height: 40vh;
+  max-height: 60rem;
   background-position: center;
   background-repeat: no-repeat;
   background-size: cover;
-  background-attachment: fixed;
 }
 .innerBanner {
   display: flex;
@@ -16,7 +16,7 @@
   justify-content: flex-end;
   margin: 0 auto;
   padding: 0 3rem;
-  padding-bottom: 7.5rem;
+  padding-bottom: 3.5rem;
   max-width: 1200px;
   height: 100%;
   color: white;

--- a/src/pages/Introduce/Board/styles.module.scss
+++ b/src/pages/Introduce/Board/styles.module.scss
@@ -54,24 +54,24 @@
 
 .content {
   & h1 {
-    font-size: 2.5rem;
-    line-height: 3.5rem;
-    margin-bottom: 1rem;
-    font-family: 'NanumSquareAcB';
-  }
-  & h2 {
     font-size: 2rem;
     line-height: 3rem;
     margin-bottom: 1rem;
     font-family: 'NanumSquareAcB';
   }
-  & h5 {
-    font-size: 1.2rem;
-    line-height: 2.2rem;
-  }
-  & p {
+  & h2 {
     font-size: 1.5rem;
     line-height: 2.5rem;
+    margin-bottom: 1rem;
+    font-family: 'NanumSquareAcB';
+  }
+  & h5 {
+    font-size: 1rem;
+    line-height: 2rem;
+  }
+  & p {
+    font-size: 1.3rem;
+    line-height: 2.3rem;
   }
   & strong {
     font-family: 'NanumSquareAcB';

--- a/src/pages/Main/styles.module.scss
+++ b/src/pages/Main/styles.module.scss
@@ -6,7 +6,8 @@
 }
 .swiperContainer {
   width: 100%;
-  height: 50rem;
+  height: 60vh;
+  max-height: 50rem;
 }
 .swiperBox {
   position: relative;

--- a/src/reset.scss
+++ b/src/reset.scss
@@ -186,24 +186,24 @@ html {
 }
 .ql-editor {
   & h1 {
-    font-size: 2.5rem !important;
-    line-height: 3.5rem;
-    font-family: 'NanumSquareAcB';
-    margin-bottom: 1rem !important;
-  }
-  & h2 {
     font-size: 2rem !important;
     line-height: 3rem;
     font-family: 'NanumSquareAcB';
     margin-bottom: 1rem !important;
   }
-  & h5 {
-    font-size: 1.2rem !important;
-    line-height: 2.2rem;
-  }
-  & p {
+  & h2 {
     font-size: 1.5rem !important;
     line-height: 2.5rem;
+    font-family: 'NanumSquareAcB';
+    margin-bottom: 1rem !important;
+  }
+  & h5 {
+    font-size: 1rem !important;
+    line-height: 2rem;
+  }
+  & p {
+    font-size: 1.3rem !important;
+    line-height: 2.3rem;
   }
   & strong {
     font-family: 'NanumSquareAcB';


### PR DESCRIPTION
## 📖 개요

메인페이지와 소개 게시글의 배너 높이와 게시글 폰트 사이즈가 너무 크다는 피드백이 있어 이에 따른 CSS 수정.

## 💻 작업사항

- 메인페이지 배너 이미지, 소개 게시글 상세 페이지 배너 이미지 height값 수정
  - heigth값을 viewport height로 어느 디바이스에서든 동일한 높이로 보이도록 수정
- 게시글 상세 페이지와 텍스트 에디터 (Quill)의 폰트 사이즈 전반적으로 수정
  - 전반적으로 0.2~0.5rem 정도 크기 축소

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
