### PR TITLE
Feat/#90 메인페이지 게시글 api 연동

### DIFF
--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -223,7 +223,11 @@ export default function MainPage() {
                     backgroundImage: `linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.35)),
                 url(${data.imageUrl})`,
                   }}
-                  onClick={() => navigate('/community')}
+                  onClick={() =>
+                    navigate(
+                      `/community/${data.prefixCategory}/${data.boardId}`,
+                    )
+                  }
                 >
                   <h1>{data.title}</h1>
                   {/* TDOO: data.content 대체 할 속성이 무엇인가? */}

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -10,6 +10,7 @@ import { Autoplay, Pagination, Navigation } from 'swiper';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import footer from '@/assets/common/footer.png';
 import { restFetcher } from '@/queryClient';
+import { getPrefixCategoryName } from '@/utils/utils';
 import { BoardMainResponse } from '@/types/boardType';
 import { jumbotronData } from '@/constants/main_dummy';
 import { opacityVariants } from '@/constants/variants';
@@ -223,11 +224,13 @@ export default function MainPage() {
                     backgroundImage: `linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.35)),
                 url(${data.imageUrl})`,
                   }}
-                  onClick={() =>
+                  onClick={() => {
                     navigate(
-                      `/community/${data.prefixCategory}/${data.boardId}`,
-                    )
-                  }
+                      `/community/${getPrefixCategoryName(
+                        data.prefixCategory,
+                      )}/${data.boardId}`,
+                    );
+                  }}
                 >
                   <h1>{data.title}</h1>
                   {/* TDOO: data.content 대체 할 속성이 무엇인가? */}

--- a/src/types/boardType.ts
+++ b/src/types/boardType.ts
@@ -45,6 +45,12 @@ export type BoardResponse = {
   data: BoardData;
 };
 
+export type BoardMainResponse = {
+  code: string;
+  message: string;
+  data: BoardContent[];
+};
+
 export type BoardForm = {
   title: string;
   code: string;


### PR DESCRIPTION
## 📖 개요
- 게시글 데이터 가져오는 새로운 api 적용

## 💻 작업사항

- 메인 페이지 / 오도이촌 소개 페이지 게시글 정보 불러오기 api 적용
- 메인 페이지 / 오도이촌 소개 페이지 새로운 api 적용함에 따라 코드 수정


## 💡 작성한 이슈 외에 작업한 사항

- 새로운 api 응답값 Type 추가 => 게시글 type 관련

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
