### PR TITLE
fix: 회원가입 페이지에서 커뮤니티 페이지 이동시 생기는 리스트 스타일 초기화 버그 수정

### DIFF
--- a/src/components/Terms/styles.module.scss
+++ b/src/components/Terms/styles.module.scss
@@ -45,21 +45,21 @@
       opacity: 0.8;
     }
   }
+  & article {
+    margin-bottom: 1rem;
+    line-height: 1.5rem;
+  }
+  & ul {
+    padding-left: 1rem;
+    list-style: disc;
+  }
+  & ol {
+    list-style: decimal;
+    padding-left: 1rem;
+  }
 }
 .title {
   font-size: 1.25rem;
   font-weight: 700;
   margin-bottom: 0.5rem;
-}
-article {
-  margin-bottom: 1rem;
-  line-height: 1.5rem;
-}
-ul {
-  padding-left: 1rem;
-  list-style: disc;
-}
-ol {
-  list-style: decimal;
-  padding-left: 1rem;
 }


### PR DESCRIPTION
## 📖 개요
회원가입 페이지에서 커뮤니티 페이지 이동시 생기는 리스트 스타일 초기화 버그 수정

## 💻 작업사항
- 회원가입 페이지 -> 커뮤니티 페이지 이동 시  전역으로 ul태그의 해당 스타일이 상속받는 것이 확인됨.
![스크린샷 2023-06-08 오후 4 08 06](https://github.com/ODOICHON/frontend/assets/83197138/774f3cbb-e193-4be3-9777-b1e6d2f4cd96)
- 해당 스타일 코드는 components/Terms의 스타일 코드로, 회원가입 페이지의 약관 컴포넌트 스타일 코드이다.
- 해당 스타일 코드에서 아래와 같이 전역적으로 태그에 대한 스타일을 적용하고 있음.
```css
article {
  margin-bottom: 1rem;
  line-height: 1.5rem;
}
ul {
  padding-left: 1rem;
  list-style: disc;
}
ol {
  list-style: decimal;
  padding-left: 1rem;
}
```

- 따라서 태그 자체에 스타일을 적용하는 것이 아닌 특정 태그의 자손태그로서의 스타일로 변경 후 적용
```css
.termsContainer {
  ...
  & article {
    margin-bottom: 1rem;
    line-height: 1.5rem;
  }
  & ul {
    padding-left: 1rem;
    list-style: disc;
  }
  & ol {
    list-style: decimal;
    padding-left: 1rem;
  }
}
```

## 💡 작성한 이슈 외에 작업한 사항

- 없음

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
