### PR TITLE
Design/#105 모바일 폰트 사이즈 조정

### DIFF
--- a/src/pages/Community/Detail/styles.module.scss
+++ b/src/pages/Community/Detail/styles.module.scss
@@ -67,6 +67,22 @@
     font-size: 1.3rem;
     line-height: 2.3rem;
   }
+  & blockquote {
+    font-size: 1.5rem;
+    line-height: 2rem;
+    margin-bottom: 0.5rem;
+  }
+  & blockquote:before {
+    content: '\201C';
+    font-family: Georgia;
+    font-size: 2rem;
+    color: #bcbcbc;
+    float: left;
+    margin: -0.5rem 0.3rem 0 0;
+  }
+  & strong {
+    font-family: 'NanumSquareAcB';
+  }
   & strong {
     font-family: 'NanumSquareAcB';
   }

--- a/src/pages/Introduce/Board/styles.module.scss
+++ b/src/pages/Introduce/Board/styles.module.scss
@@ -73,6 +73,19 @@
     font-size: 1.3rem;
     line-height: 2.3rem;
   }
+  & blockquote {
+    font-size: 1.5rem;
+    line-height: 2rem;
+    margin-bottom: 0.5rem;
+  }
+  & blockquote:before {
+    content: '\201C';
+    font-family: Georgia;
+    font-size: 2rem;
+    color: #bcbcbc;
+    float: left;
+    margin: -0.5rem 0.3rem 0 0;
+  }
   & strong {
     font-family: 'NanumSquareAcB';
   }

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -9,7 +9,7 @@ import { motion } from 'framer-motion';
 import { Autoplay, Pagination, Navigation } from 'swiper';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import footer from '@/assets/common/footer.png';
-import { restFetcher } from '@/queryClient';
+import { QueryKeys, restFetcher } from '@/queryClient';
 import { getPrefixCategoryName } from '@/utils/utils';
 import { BoardMainResponse } from '@/types/boardType';
 import { jumbotronData } from '@/constants/main_dummy';
@@ -26,7 +26,7 @@ export default function MainPage() {
   const commuPrevRef = useRef<HTMLButtonElement>(null);
 
   const { data: introData } = useQuery<BoardMainResponse>(
-    ['PREVIEW_BOARD', introToggle],
+    [QueryKeys.PREVIEW_BOARD, QueryKeys.INTRO_BOARD, introToggle],
     () =>
       restFetcher({
         method: 'GET',
@@ -39,7 +39,7 @@ export default function MainPage() {
       }),
   );
   const { data: communityData } = useQuery<BoardMainResponse>(
-    ['PREVIEW_BOARD', 'COMMUNITY'],
+    [QueryKeys.PREVIEW_BOARD, QueryKeys.COMMUNITY_BOARD],
     () =>
       restFetcher({
         method: 'GET',
@@ -233,7 +233,6 @@ export default function MainPage() {
                   }}
                 >
                   <h1>{data.title}</h1>
-                  {/* TDOO: data.content 대체 할 속성이 무엇인가? */}
                   <p>{data.oneLineContent}</p>
                   <div className={styles.commuMeta}>
                     <p>{dayjs(data.createdAt).format('YYYY-MM-DD')}</p>

--- a/src/pages/Main/styles.module.scss
+++ b/src/pages/Main/styles.module.scss
@@ -201,6 +201,18 @@
     -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
   }
+
+  @include mobile {
+    padding-top: 5rem;
+    font-size: 2.3rem;
+    & h3 {
+      line-height: 2.8rem;
+    }
+    & p {
+      font-size: 1.5rem;
+      line-height: 2rem;
+    }
+  }
 }
 .odoiIntro_slide_image {
   flex-grow: 1;
@@ -240,7 +252,7 @@
     white-space: pre-line;
   }
   @include mobile {
-    padding: 3rem 6rem;
+    padding: 3rem;
   }
 }
 .communitySwiper {

--- a/src/queryClient.ts
+++ b/src/queryClient.ts
@@ -55,6 +55,7 @@ export const restFetcher = async ({
 
 export const QueryKeys = {
   USER: 'USER',
+  PREVIEW_BOARD: 'PREVIEW_BOARD',
   INTRO_BOARD: 'INTRO_BOARD',
   COMMUNITY_BOARD: 'COMMUNITY_BOARD',
   LIKE: 'LIKE',

--- a/src/reset.scss
+++ b/src/reset.scss
@@ -149,7 +149,7 @@ table {
   box-sizing: border-box;
 }
 html {
-  font-size: 52.5%; // 1rem = 8.4px;
+  font-size: 53.125%; // 1rem = 8.5px;
   @include tablet {
     font-size: 62.5%; // 1rem = 10px;
   }

--- a/src/reset.scss
+++ b/src/reset.scss
@@ -205,6 +205,22 @@ html {
     font-size: 1.3rem !important;
     line-height: 2.3rem;
   }
+  & blockquote {
+    font-size: 1.5rem;
+    line-height: 2rem;
+    margin-bottom: 0.5rem;
+  }
+  & blockquote:before {
+    content: '\201C';
+    font-family: Georgia;
+    font-size: 2rem;
+    color: #bcbcbc;
+    float: left;
+    margin: -0.5rem 0.3rem 0 0;
+  }
+  & strong {
+    font-family: 'NanumSquareAcB';
+  }
   & strong {
     font-family: 'NanumSquareAcB';
   }


### PR DESCRIPTION
## 📖 개요
모바일 사이즈에서 폰트 사이즈 조정

## 💻 작업사항

- 모바일 사이즈에서 body의 font-size를 53.125%로 수정 (1rem = 9px)
- 메인페이지 소개글 모바일 화면에서 폰트사이즈 크기 증가

## 💡 작성한 이슈 외에 작업한 사항

- Quill 게시글 / 게시글 상세 페이지에서 blockquote 태그 인용문 스타일 추가

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
