### PR TITLE
Design/#132 게시글 에디터 높이 CSS 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "framer-motion": "^10.2.3",
     "lodash": "^4.17.21",
     "msw": "^1.0.1",
+    "quill-image-resize-module-ts": "^3.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-ga": "^3.3.1",

--- a/src/apis/uploadS3.ts
+++ b/src/apis/uploadS3.ts
@@ -28,7 +28,7 @@ export const uploadFile = async (file: File) => {
   };
   try {
     const { Location } = await s3.upload(params).promise();
-    return Location;
+    return { Location, name };
   } catch (err) {
     alert((err as AxiosError<ErrorResponse>).response?.data.message);
   }

--- a/src/components/Community/Quill/index.tsx
+++ b/src/components/Community/Quill/index.tsx
@@ -112,13 +112,9 @@ export default function CommunityQuill({ queryParam }: CommunityQuillProps) {
   return (
     <div className={styles.container}>
       <Title category={queryParam} boardData={boardData} />
-      <div className={styles.sectionWrapper}>
-        <section className={styles.labelSection}>
+      <section className={styles.sectionWrapper}>
+        <span className={styles.inputWrapper}>
           <label>말머리</label>
-          <label>제목</label>
-          <label>내용</label>
-        </section>
-        <section className={styles.contentSection}>
           <select
             className={styles.categoryInput}
             name="category"
@@ -138,6 +134,9 @@ export default function CommunityQuill({ queryParam }: CommunityQuillProps) {
                 </option>
               ))}
           </select>
+        </span>
+        <span className={styles.inputWrapper}>
+          <label>제목</label>
           <input
             className={styles.titleInput}
             type="text"
@@ -147,7 +146,9 @@ export default function CommunityQuill({ queryParam }: CommunityQuillProps) {
               setTitle(e.target.value)
             }
           />
-
+        </span>
+        <span className={styles.inputWrapper}>
+          <label>내용</label>
           <ReactQuill
             className={styles.quill}
             ref={(element) => {
@@ -158,8 +159,8 @@ export default function CommunityQuill({ queryParam }: CommunityQuillProps) {
             onChange={onChange}
             modules={modules}
           />
-        </section>
-      </div>
+        </span>
+      </section>
       <section>
         {boardData ? (
           <button type="button" onClick={onUpdate}>

--- a/src/components/Community/Quill/styles.module.scss
+++ b/src/components/Community/Quill/styles.module.scss
@@ -2,9 +2,10 @@
 .quill {
   display: flex;
   flex-direction: column;
+  width: 100%;
+  min-height: 40rem;
+  overflow-y: auto;
   font-family: 'NanumSquareAcR';
-  height: 40rem;
-  overflow-y: scroll;
 }
 
 // 페이지 스타일링
@@ -15,7 +16,6 @@
   max-width: 1200px;
   margin: 0 auto;
   margin-bottom: 4.5rem;
-
   padding: 1rem;
 
   & > h1 {
@@ -54,11 +54,25 @@
   }
 }
 
+.sectionWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+  height: 100%;
+  margin-bottom: 2rem;
+  & > span:last-child {
+    min-height: 40rem;
+    height: 100%;
+  }
+}
+
 .labelStyle {
+  flex-shrink: 0;
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 3.75rem;
+  height: 100%;
   background-color: var(--gray-color);
   font-family: 'Pretendard';
   font-size: 1.375rem;
@@ -71,48 +85,41 @@
   align-items: center;
   height: 3.75rem;
   padding: 0 1rem;
-  border: 1px solid var(--darkgray-color);
+  border: 1px solid #ccc;
   border-radius: 8px;
   outline: none;
 }
 
-.sectionWrapper {
+.inputWrapper {
   display: flex;
   gap: 1rem;
-  width: 100%;
-  margin-bottom: 2rem;
-}
-.labelSection {
-  flex-shrink: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  width: 11rem;
-  & > label {
-    @extend .labelStyle;
+  height: 3.75rem;
+  &:last-child {
+    & > label {
+      min-height: 40rem;
+      height: auto;
+    }
   }
-  & > label:last-child {
-    height: 40rem;
+  & > input {
+    @extend .contentStyle;
+    width: 100%;
   }
-  @include mobile {
-    display: none;
-  }
-}
-
-.contentSection {
-  flex-grow: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  & > .thumbnailWrapper input,
-  & > input,
   & > select {
     @extend .contentStyle;
   }
-  & > .categoryInput {
-    width: 18rem;
-    & > option[value=''][disabled] {
+  & > label {
+    @extend .labelStyle;
+    width: 11rem;
+
+    @include mobile {
       display: none;
     }
+  }
+}
+
+.categoryInput {
+  width: 18rem;
+  & > option[value=''][disabled] {
+    display: none;
   }
 }

--- a/src/components/Introduce/Quill/index.tsx
+++ b/src/components/Introduce/Quill/index.tsx
@@ -126,14 +126,9 @@ export default function IntroduceQuill() {
   return (
     <div className={styles.container}>
       <h1>{boardData ? '관리자 글 수정하기' : '관리자 글쓰기'}</h1>
-      <div className={styles.sectionWrapper}>
-        <section className={styles.labelSection}>
+      <section className={styles.sectionWrapper}>
+        <span className={styles.inputWrapper}>
           <label>말머리</label>
-          <label>제목</label>
-          <label>썸네일</label>
-          <label>내용</label>
-        </section>
-        <section className={styles.contentSection}>
           <select
             className={styles.categoryInput}
             name="category"
@@ -148,6 +143,9 @@ export default function IntroduceQuill() {
             <option value="TREND">트렌드</option>
             <option value="REVIEW">후기</option>
           </select>
+        </span>
+        <span className={styles.inputWrapper}>
+          <label>제목</label>
           <input
             className={styles.titleInput}
             type="text"
@@ -157,6 +155,9 @@ export default function IntroduceQuill() {
               setTitle(e.target.value)
             }
           />
+        </span>
+        <span className={styles.inputWrapper}>
+          <label>썸네일</label>
           <div className={styles.thumbnailWrapper}>
             <input
               type="text"
@@ -174,6 +175,9 @@ export default function IntroduceQuill() {
               업로드
             </button>
           </div>
+        </span>
+        <span className={styles.inputWrapper}>
+          <label>내용</label>
           <ReactQuill
             className={styles.quill}
             ref={(element) => {
@@ -184,8 +188,8 @@ export default function IntroduceQuill() {
             onChange={onChange}
             modules={modules}
           />
-        </section>
-      </div>
+        </span>
+      </section>
       {boardData ? (
         <button type="button" onClick={onUpdate}>
           수정하기

--- a/src/components/Introduce/Quill/styles.module.scss
+++ b/src/components/Introduce/Quill/styles.module.scss
@@ -2,9 +2,10 @@
 .quill {
   display: flex;
   flex-direction: column;
+  width: 100%;
+  min-height: 40rem;
+  overflow-y: auto;
   font-family: 'NanumSquareAcR';
-  height: 40rem;
-  overflow-y: scroll;
 }
 
 // 페이지 스타일링
@@ -24,6 +25,7 @@
     margin-top: 5.25rem;
     margin-bottom: 3rem;
   }
+
   & > button {
     align-self: flex-end;
     width: 7.5rem;
@@ -41,11 +43,25 @@
   }
 }
 
+.sectionWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+  height: 100%;
+  margin-bottom: 2rem;
+  & > span:last-child {
+    min-height: 40rem;
+    height: 100%;
+  }
+}
+
 .labelStyle {
+  flex-shrink: 0;
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 3.75rem;
+  height: 100%;
   background-color: var(--gray-color);
   font-family: 'Pretendard';
   font-size: 1.375rem;
@@ -58,37 +74,43 @@
   align-items: center;
   height: 3.75rem;
   padding: 0 1rem;
-  border: 1px solid var(--darkgray-color);
+  border: 1px solid #ccc;
   border-radius: 8px;
   outline: none;
 }
 
-.sectionWrapper {
+.inputWrapper {
   display: flex;
   gap: 1rem;
-  width: 100%;
-  margin-bottom: 2rem;
-}
-.labelSection {
-  flex-shrink: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  width: 11rem;
+  height: 3.75rem;
+  &:last-child {
+    & > label {
+      min-height: 40rem;
+      height: auto;
+    }
+  }
+  & > input {
+    @extend .contentStyle;
+    width: 100%;
+  }
+  & > select {
+    @extend .contentStyle;
+  }
   & > label {
     @extend .labelStyle;
-  }
-  & > label:last-child {
-    height: 40rem;
-  }
-  @include mobile {
-    display: none;
+    width: 11rem;
+
+    @include mobile {
+      display: none;
+    }
   }
 }
+
 .thumbnailWrapper {
   display: flex;
   gap: 1rem;
   & > input {
+    @extend .contentStyle;
     width: 18rem;
   }
   & > button {
@@ -106,20 +128,10 @@
     }
   }
 }
-.contentSection {
-  flex-grow: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  & > .thumbnailWrapper input,
-  & > input,
-  & > select {
-    @extend .contentStyle;
-  }
-  & > .categoryInput {
-    width: 18rem;
-    & > option[value=''][disabled] {
-      display: none;
-    }
+
+.categoryInput {
+  width: 18rem;
+  & > option[value=''][disabled] {
+    display: none;
   }
 }

--- a/src/components/Trade/SearchBar/styles.module.scss
+++ b/src/components/Trade/SearchBar/styles.module.scss
@@ -1,1 +1,1 @@
-@import '@/media.scss';
+@import '@/styles/media.scss';

--- a/src/hooks/useQuillModules.ts
+++ b/src/hooks/useQuillModules.ts
@@ -1,12 +1,23 @@
 import { useMemo } from 'react';
-import ReactQuill from 'react-quill';
+import ReactQuill, { Quill } from 'react-quill';
+import { ImageResize } from 'quill-image-resize-module-ts';
 import imageHandler from '@/utils/Quill/imageHandler';
+
+Quill.register('modules/imageResize', ImageResize);
 
 const useQuillModules = (
   QuillRef: React.MutableRefObject<ReactQuill | undefined>,
 ) => {
   const modules = useMemo(
     () => ({
+      imageResize: {
+        displayStyles: {
+          backgroundColor: 'black',
+          border: 'none',
+          color: 'white',
+        },
+        modules: ['Resize', 'DisplaySize', 'Toolbar'],
+      },
       toolbar: {
         container: [
           [{ header: [1, 2, 5, false] }],

--- a/src/hooks/useQuillModules.ts
+++ b/src/hooks/useQuillModules.ts
@@ -3,6 +3,11 @@ import ReactQuill, { Quill } from 'react-quill';
 import { ImageResize } from 'quill-image-resize-module-ts';
 import imageHandler from '@/utils/Quill/imageHandler';
 
+const Align = ReactQuill.Quill.import('formats/align');
+Align.whitelist = ['left', 'center', 'right', 'justify'];
+const Icons = ReactQuill.Quill.import('ui/icons');
+Icons.align.left = Icons.align[''];
+
 Quill.register('modules/imageResize', ImageResize);
 
 const useQuillModules = (
@@ -22,6 +27,7 @@ const useQuillModules = (
         container: [
           [{ header: [1, 2, 5, false] }],
           ['bold', 'underline', 'strike', 'blockquote'],
+          [{ align: ['left', 'center', 'right', 'justify'] }],
           [
             { list: 'ordered' },
             { list: 'bullet' },

--- a/src/pages/Trade/styles.module.scss
+++ b/src/pages/Trade/styles.module.scss
@@ -1,4 +1,4 @@
-@import '@/media.scss';
+@import '@/styles/media.scss';
 .container {
   width: 100%;
   margin: 0 auto;

--- a/src/styles/editor.scss
+++ b/src/styles/editor.scss
@@ -57,8 +57,7 @@
   display: list-item;
   text-align: -webkit-match-parent;
 }
+
 & img {
-  max-width: 100%;
-  margin-top: 0.5rem;
-  margin-bottom: 0.5rem;
+  margin: 0.5rem 0;
 }

--- a/src/styles/reset.scss
+++ b/src/styles/reset.scss
@@ -179,10 +179,11 @@ html {
 .ql-toolbar {
   position: sticky;
   z-index: 50;
+  border-radius: 8px 8px 0 0;
 }
 .ql-container {
-  overflow-y: scroll;
   padding-bottom: 3rem;
+  border-radius: 0 0 8px 8px;
 }
 .ql-editor {
   @import '@/styles/editor.scss';

--- a/src/utils/Quill/imageHandler.ts
+++ b/src/utils/Quill/imageHandler.ts
@@ -17,17 +17,13 @@ const imageHandler = (
       const file = input.files[0];
       try {
         const res = await uploadFile(file);
-        const url = res || '';
+        const url = res?.Location || '';
         const range = QuillRef.current?.getEditor().getSelection()?.index;
         if (range !== null && range !== undefined) {
           const quill = QuillRef.current?.getEditor();
-
-          quill?.setSelection(range, 1);
-
-          quill?.clipboard.dangerouslyPasteHTML(
-            range,
-            `<img src=${url} alt="이미지" />`,
-          );
+          quill?.insertEmbed(range, 'image', url);
+          quill?.insertText(range + 1, '\n');
+          quill?.setSelection({ index: range + 2, length: 0 });
         }
       } catch (error) {
         alert((error as AxiosError<ErrorResponse>).response?.data.message);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3012,7 +3012,15 @@ quill-delta@^3.6.2:
     extend "^3.0.2"
     fast-diff "1.1.2"
 
-quill@^1.3.7:
+quill-image-resize-module-ts@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/quill-image-resize-module-ts/-/quill-image-resize-module-ts-3.0.3.tgz#47e6d81214719b7a745c2d4e53cad2cef09ad4dc"
+  integrity sha512-NMWw67zCfGxE0AyPTVLWMTAs71eKerd+jJJqu9ZuPBGZl7vc+Jtb+tmfx33pC3h0deVYqgOMXYzbFBIRmu/WuQ==
+  dependencies:
+    lodash "^4.17.4"
+    quill "^1.3.4"
+
+quill@^1.3.4, quill@^1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/quill/-/quill-1.3.7.tgz#da5b2f3a2c470e932340cdbf3668c9f21f9286e8"
   integrity sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==


### PR DESCRIPTION
## 📖 개요
게시글 에디터 높이가 현재는 오버 시 scroll이 되는 형식인데, 높이가 늘어나는 형식으로 변경

## 💻 작업사항

- Community 게시글 작성 페이지 코드 구조 변경, CSS 수정
- Introduce 게시글 작성 페이지 코드 구조 변경, CSS 수정

## 💡 작성한 이슈 외에 작업한 사항

- 코드 구조 변경 사항
  - 기존 <labelSection>과 <ContentSection>을 구분하여 태그 구조를 쌓았음.
  - 리팩토링 이후, <inputWrapper>안에서 label과 content를 포함하는 구조로 리팩토링
- Quill 에디터에 이미지 리사이즈 모듈 추가
  - `yarn add quill-image-resize-module-ts` 패키지 설치 후 적용
  - 사용자가 에디터에서 이미지 업로드 후 자유롭게 이미지 사이즈 조절 가능

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
