### PR TITLE
design: 게시글 작성에서 스크롤 시 에디터 툴바 화면에 고정

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 <body>
   <div id="root"></div>
   <script type="text/javascript"
-    src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%VITE_KAKAO_MAP_API_KEY%&libraries=services,clusterer"></script>
+    src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%VITE_KAKAO_MAP_JAVASCRIPT_KEY%&libraries=services,clusterer"></script>
   <script type="module" src="/src/main.tsx"></script>
 </body>
 </html>

--- a/src/components/Community/Quill/styles.module.scss
+++ b/src/components/Community/Quill/styles.module.scss
@@ -1,11 +1,18 @@
 @import '@/styles/media.scss';
+
 .quill {
   display: flex;
   flex-direction: column;
   width: 100%;
   min-height: 40rem;
-  overflow-y: auto;
   font-family: 'NanumSquareAcR';
+  & > div:first-child {
+    top: calc(77px + 70px);
+
+    @include mobile {
+      top: calc(50px + 40px);
+    }
+  }
 }
 
 // 페이지 스타일링

--- a/src/components/Introduce/Quill/styles.module.scss
+++ b/src/components/Introduce/Quill/styles.module.scss
@@ -1,11 +1,19 @@
 @import '@/styles/media.scss';
+
 .quill {
   display: flex;
   flex-direction: column;
   width: 100%;
   min-height: 40rem;
-  overflow-y: auto;
   font-family: 'NanumSquareAcR';
+
+  & > div:first-child {
+    top: 77px;
+
+    @include mobile {
+      top: 50px;
+    }
+  }
 }
 
 // 페이지 스타일링

--- a/src/styles/editor.scss
+++ b/src/styles/editor.scss
@@ -61,4 +61,5 @@
 & img {
   max-width: 100%;
   margin: 0.5rem 0;
+  border-radius: 8px;
 }

--- a/src/styles/editor.scss
+++ b/src/styles/editor.scss
@@ -59,5 +59,6 @@
 }
 
 & img {
+  max-width: 100%;
   margin: 0.5rem 0;
 }

--- a/src/styles/reset.scss
+++ b/src/styles/reset.scss
@@ -180,6 +180,7 @@ html {
   position: sticky;
   z-index: 50;
   border-radius: 8px 8px 0 0;
+  background-color: white;
 }
 .ql-container {
   padding-bottom: 3rem;


### PR DESCRIPTION
## 📖 개요
게시글 작성에서 화면 스크롤 시 에디터 툴바 화면에 고정하도록 CSS 수정

## 💻 작업사항

- ql-toolbar를 `position: sticky`로 하고, 소개 게시글과 커뮤니티 게시글의 top이 다르므로 (navbar 때문) 각각 스타일 코드에서 top 값을 적용시켰습니다.

## 💡 작성한 이슈 외에 작업한 사항

- 게시글의 이미지의 max-height를 100%로 수정했습니다.

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
