### PR TITLE
fix: React GA4 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "quill-image-resize-module-ts": "^3.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-ga": "^3.3.1",
+    "react-ga4": "^2.1.0",
     "react-hook-form": "^7.43.5",
     "react-icons": "^4.8.0",
     "react-kakao-maps-sdk": "^1.1.9",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,15 @@
-import ReactGA from 'react-ga';
 import { useRoutes } from 'react-router-dom';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { routes } from '@/Routes';
+import useReactGA from './hooks/useReactGA';
 import { getClient } from './queryClient';
 
-const GA_TRACK_ID = import.meta.env.VITE_GA_TRACK_ID;
-
 export default function App() {
+  useReactGA();
+
   const queryClient = getClient();
   const elem = useRoutes(routes);
-
-  ReactGA.initialize(GA_TRACK_ID);
-  ReactGA.pageview(window.location.pathname + window.location.search);
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/src/hooks/useReactGA.ts
+++ b/src/hooks/useReactGA.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+import ReactGA from 'react-ga4';
+import { useLocation } from 'react-router-dom';
+
+/**
+ * uri 변경 추적 컴포넌트
+ * uri가 변경될 때마다 pageview 이벤트 전송
+ */
+
+const GA_TRACK_ID = import.meta.env.VITE_GA_TRACK_ID;
+
+const useReactGA = () => {
+  const location = useLocation();
+  const [initialized, setInitialized] = useState(false);
+
+  // localhost는 기록하지 않음
+  useEffect(() => {
+    if (!window.location.href.includes('localhost')) {
+      ReactGA.initialize(GA_TRACK_ID);
+      setInitialized(true);
+    }
+  }, []);
+
+  // location 변경 감지시 pageview 이벤트 전송
+  useEffect(() => {
+    if (initialized) {
+      ReactGA.set({ page: location.pathname });
+      ReactGA.send('pageview');
+    }
+  }, [initialized, location]);
+};
+
+export default useReactGA;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3040,10 +3040,10 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
-react-ga@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-3.3.1.tgz#d8e1f4e05ec55ed6ff944dcb14b99011dfaf9504"
-  integrity sha512-4Vc0W5EvXAXUN/wWyxvsAKDLLgtJ3oLmhYYssx+YzphJpejtOst6cbIHCIyF50Fdxuf5DDKqRYny24yJ2y7GFQ==
+react-ga4@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-ga4/-/react-ga4-2.1.0.tgz#56601f59d95c08466ebd6edfbf8dede55c4678f9"
+  integrity sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ==
 
 react-hook-form@^7.43.5:
   version "7.43.9"


### PR DESCRIPTION
## 📖 개요

GA Universe가 2023/07/01 부로 지원하지 않게 됨으로 React GA4로 마이그레이션

## 💻 작업사항

- react-ga 라이브러리 uninstall
- react-ga4 라이브러리 설치
- GA4 세팅 커스텀 훅인 useReactGA 코드 생성

## 💡 작성한 이슈 외에 작업한 사항

없음

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
