### PR TITLE
design: 메인페이지 소개 카드 이미지높이 및 제목 ellipsis 적용

### DIFF
--- a/src/pages/Main/styles.module.scss
+++ b/src/pages/Main/styles.module.scss
@@ -162,7 +162,6 @@
     height: 50rem;
     border-top: 1px solid var(--gray-color);
     border-bottom: 1px solid var(--gray-color);
-    // border-left: none;
   }
 }
 .odoiIntro_slide_last {
@@ -184,6 +183,13 @@
   height: 50%;
   & h3 {
     line-height: 2rem;
+    overflow: hidden;
+    word-break: break-all;
+    text-overflow: ellipsis;
+    white-space: normal;
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
   }
   & p {
     margin-top: 1.125rem;
@@ -214,8 +220,8 @@
   }
 }
 .odoiIntro_slide_image {
-  flex-grow: 1;
   object-fit: cover;
+  height: 50%;
 }
 .sectionSwiper {
   flex: 0.56;


### PR DESCRIPTION
## 📖 개요

메인페이지에서 소개 카드 타이틀 ellipsis 적용 및 이미지 height 조정

## 💻 작업사항

-  소개 타이틀이 줄 넘어가면서 다른 영역의 스타일 침범이 일어남에 따라 1줄 이상 넘어가면 ellipsis가 되도록 적용
- 이미지 높이를 50%로 고정

## 💡 작성한 이슈 외에 작업한 사항

- 없음

## ✔️ check list

- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
