### PR TITLE
Hotfix/#144 이미지 업로드 시 이미지 이름 고유값으로 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-router-dom": "^6.8.1",
     "sass": "^1.58.1",
     "swiper": "^9.0.5",
+    "uuid": "^9.0.0",
     "vite": "^4.1.0",
     "vite-tsconfig-paths": "^4.0.5",
     "zustand": "^4.3.6"
@@ -48,6 +49,7 @@
     "@types/node": "^18.13.0",
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
+    "@types/uuid": "^9.0.2",
     "@typescript-eslint/eslint-plugin": "^5.52.0",
     "@typescript-eslint/parser": "^5.52.0",
     "eslint": "^8.39.0",

--- a/src/apis/uploadS3.ts
+++ b/src/apis/uploadS3.ts
@@ -1,5 +1,6 @@
 import AWS from 'aws-sdk';
 import { AxiosError } from 'axios';
+import { v1 } from 'uuid';
 import { ApiResponseType } from '@/types/apiResponseType';
 
 const {
@@ -18,17 +19,19 @@ const s3 = new AWS.S3();
 const bucketName = VITE_S3_BUCKET_NAME;
 
 export const uploadFile = async (file: File) => {
-  const { name, type } = file;
+  const { type, name } = file;
   const params = {
     Bucket: bucketName,
-    Key: `${name}`,
+    Key: `${name}/${v1().toString().replace('-', '')}.${
+      file.type.split('/')[1]
+    }`,
     Body: file,
     ContentType: type,
     ACL: 'public-read',
   };
   try {
     const { Location } = await s3.upload(params).promise();
-    return { Location, name };
+    return Location;
   } catch (err) {
     alert((err as AxiosError<ApiResponseType>).response?.data.message);
   }

--- a/src/apis/uploadS3.ts
+++ b/src/apis/uploadS3.ts
@@ -1,6 +1,6 @@
 import AWS from 'aws-sdk';
 import { AxiosError } from 'axios';
-import { v1 } from 'uuid';
+import { v4 } from 'uuid';
 import { ApiResponseType } from '@/types/apiResponseType';
 
 const {
@@ -22,7 +22,7 @@ export const uploadFile = async (file: File) => {
   const { type, name } = file;
   const params = {
     Bucket: bucketName,
-    Key: `${name}/${v1().toString().replace('-', '')}.${
+    Key: `${name}/${v4().toString().replace('-', '')}.${
       file.type.split('/')[1]
     }`,
     Body: file,

--- a/src/components/Introduce/Quill/index.tsx
+++ b/src/components/Introduce/Quill/index.tsx
@@ -70,7 +70,7 @@ export default function IntroduceQuill() {
       setThumbnailTitle(e.currentTarget.files[0].name);
       try {
         const res = await uploadFile(file);
-        const url = res?.Location || '';
+        const url = res || '';
         const imageName = url.split(VITE_S3_DOMAIN)[1];
         const imageUrl = VITE_CLOUD_FRONT_DOMAIN + imageName + DEFAULT_OPTIONS;
         setThumbnail(imageUrl);

--- a/src/utils/Quill/imageHandler.ts
+++ b/src/utils/Quill/imageHandler.ts
@@ -20,7 +20,7 @@ const imageHandler = (
       const file = input.files[0];
       try {
         const res = await uploadFile(file);
-        const url = res?.Location || '';
+        const url = res || '';
         const imageName = url.split(VITE_S3_DOMAIN)[1];
         const imageUrl = VITE_CLOUD_FRONT_DOMAIN + imageName + DEFAULT_OPTIONS;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -620,6 +620,11 @@
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.3.tgz#a136f83b0758698df454e328759dbd3d44555311"
   integrity sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==
 
+"@types/uuid@^9.0.2":
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.2.tgz#ede1d1b1e451548d44919dc226253e32a6952c4b"
+  integrity sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==
+
 "@typescript-eslint/eslint-plugin@^5.52.0":
   version "5.59.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.1.tgz#9b09ee1541bff1d2cebdcb87e7ce4a4003acde08"
@@ -3691,6 +3696,11 @@ uuid@8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.0.0.tgz#bc6ccf91b5ff0ac07bbcdbf1c7c4e150db4dbb6c"
   integrity sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==
+
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 vite-tsconfig-paths@^4.0.5:
   version "4.2.0"


### PR DESCRIPTION
## 📖 개요

이미지 업로드 시 중복된 이름의 이미지일 경우 이전 이미지가 보이는 현상 발생
따라서 이미지 이름을 고유값으로 적용

## 💻 작업사항

- uuid 라이브러리를 활용해서 이미지 고유 이름 생성

## 💡 작성한 이슈 외에 작업한 사항

- 없음

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
