### PR TITLE
Refact/#148 좋아요 로직 리펙토링 ( 낙관적 업데이트 )

### DIFF
--- a/src/components/Board/Like/index.tsx
+++ b/src/components/Board/Like/index.tsx
@@ -21,20 +21,25 @@ export default function Like({ boardId, loveCount, intro }: LikeProps) {
     { enabled: !!user },
   );
   const { mutate: clickLove } = useMutation(
-    () => restFetcher({ method: 'PUT', path: `/loves/${boardId}` }),
+    () =>
+      restFetcher({
+        method: isLove?.data ? 'DELETE' : 'PUT',
+        path: `/loves/${boardId}`,
+      }),
     {
       onMutate: async () => {
         // 데이터에 대한 모든 퀴리요청을 취소하여 이전 서버 데이터가 낙관적 업데이트를 덮어쓰지 않도록.
         queryClient.cancelQueries([QueryKeys.LIKE]);
 
         // 이전 값의 snapshot
-        const previousLikeData = queryClient.getQueriesData([QueryKeys.LIKE]);
+        const previousLikeData = queryClient.getQueriesData<
+          ApiResponseWithDataType<boolean>
+        >([QueryKeys.LIKE, boardId])[0][1];
 
         //  낙관적업데이트는 새로운 사용자 값으로 캐시를 업데이트.
-        queryClient.setQueryData([QueryKeys.LIKE], {
-          code: 'SUCCESS',
-          message: '성공',
-          data: true,
+        queryClient.setQueryData([QueryKeys.LIKE, boardId], {
+          ...previousLikeData,
+          data: !previousLikeData?.data,
         });
 
         //  snapshot 값이 있는 컨텍스트 객체 반환
@@ -42,57 +47,12 @@ export default function Like({ boardId, loveCount, intro }: LikeProps) {
       },
       onError: (error, newData, context) => {
         // 캐시를 저장된 값으로 롤백
-        if (context?.previousLikeData) {
-          queryClient.setQueryData([QueryKeys.LIKE], {
-            code: 'SUCCESS',
-            message: '성공',
-            data: false,
-          });
-        }
-      },
-      onSettled: () => {
-        // 쿼리 함수의 성공, 실패 두 경우 모두 실행.
-        queryClient.refetchQueries([QueryKeys.LIKE]);
-        // TODO: 이후 소개 페이지가 아닐 시 실행할 쿼리키 등록
-        return queryClient.refetchQueries([
-          intro ? QueryKeys.INTRO_BOARD : QueryKeys.COMMUNITY_BOARD,
-        ]);
-      },
-    },
-  );
-  const { mutate: cancelLove } = useMutation(
-    () => restFetcher({ method: 'DELETE', path: `/loves/${boardId}` }),
-    {
-      onMutate: async () => {
-        // 데이터에 대한 모든 퀴리요청을 취소하여 이전 서버 데이터가 낙관적 업데이트를 덮어쓰지 않도록.
-        queryClient.cancelQueries([QueryKeys.LIKE]);
-
-        // 이전 값의 snapshot
-        const previousLikeData = queryClient.getQueriesData([QueryKeys.LIKE]);
-
-        //  낙관적업데이트는 새로운 사용자 값으로 캐시를 업데이트.
-        queryClient.setQueryData([QueryKeys.LIKE], {
-          code: 'SUCCESS',
-          message: '성공',
-          data: false,
+        queryClient.setQueryData([QueryKeys.LIKE, boardId], {
+          ...context?.previousLikeData,
         });
-
-        //  snapshot 값이 있는 컨텍스트 객체 반환
-        return { previousLikeData };
-      },
-      onError: (error, newData, context) => {
-        // 캐시를 저장된 값으로 롤백
-        if (context?.previousLikeData) {
-          queryClient.setQueryData([QueryKeys.LIKE], {
-            code: 'SUCCESS',
-            message: '성공',
-            data: true,
-          });
-        }
       },
       onSettled: () => {
         // 쿼리 함수의 성공, 실패 두 경우 모두 실행.
-        queryClient.refetchQueries([QueryKeys.LIKE]);
         // TODO: 이후 소개 페이지가 아닐 시 실행할 쿼리키 등록
         return queryClient.refetchQueries([
           intro ? QueryKeys.INTRO_BOARD : QueryKeys.COMMUNITY_BOARD,
@@ -100,12 +60,13 @@ export default function Like({ boardId, loveCount, intro }: LikeProps) {
       },
     },
   );
+
   const onClickButton = () => {
     if (!user) {
       alert('로그인 후 이용 가능합니다.');
       return;
     }
-    isLove?.data ? cancelLove() : clickLove();
+    clickLove();
   };
   return (
     <div className={styles.wrapper}>


### PR DESCRIPTION
## 📖 개요
- 좋아요 낙관적 업데이트 리펙토링

## 💻 작업사항

- 좋아요 버튼 누르면 즉각 표시 로직 중복로직 제거
- 좋아요 수 업데이트 낙관적 적용 안된거 적용
  - 기존 로직에서 좋아요 수는 좋아요 버튼이 낙관적으로 업데이트가 되고 실제 api 요청을 성공하면 onSettled 옵션을 통해 retch를 하고 업데이트 된 값을 가지고 렌더링 하다보니 좋아요 수는 낙관적으로 업데이트가 진행되지 않더라구요! 그래서 적용을 해봤습니다. 커밋을 2개로 적용하기 전과 후로 나눠놨고 확인 가능하도록 해놨습니다!
  - 좋아요 버튼은 낙관적이 되는데, 좋아요 수는 낙관적이 안되면 사용자 경험에 좋지 않을 것 같아서 작업했습니다. 그렇다면 내부적인 로직으로 봤을 때, api요청을 더 하게 되는가? 그렇지 않습니다. 결과적으로 같은 결과는 내는데 동일한 api 호출 횟수로 요청합니다. 좋아요 수를 낙관적 업데이트 한다고 해서 성능이 나빠지지는 않는다고 생각합니다!

## 💡 작성한 이슈 외에 작업한 사항

- X

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
