### PR TITLE
fix: 커뮤니티 글쓰기 제목 수정

### DIFF
--- a/src/components/Community/Title/index.tsx
+++ b/src/components/Community/Title/index.tsx
@@ -6,7 +6,7 @@ type TitleProps = {
 };
 
 export default function Title({ category, boardData }: TitleProps) {
-  const title = category === 'free' ? '자유게시판' : '홍보게시판';
+  const title = category === 'free_board' ? '자유게시판' : '홍보게시판';
 
   return <h1>{boardData ? `${title} 수정하기` : `${title} 글쓰기`}</h1>;
 }


### PR DESCRIPTION
## 📖 개요
커뮤니티 글쓰기 페이지 제목이 "홍보게시판 글쓰기"로 고정되는 버그 수정

## 💻 작업사항

```tsx
export default function Title({ category, boardData }: TitleProps) {
  const title = category === 'free_board' ? '자유게시판' : '홍보게시판';

  return <h1>{boardData ? `${title} 수정하기` : `${title} 글쓰기`}</h1>;
}
```

기존에는 `category === 'free'`로 비교했던 코드를 `category === 'free_board'`로 수정

## 💡 작성한 이슈 외에 작업한 사항

- 없음

## ✔️ check list

- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
