### PR TITLE
Fix/#190 빈집거래 페이지 상단 필터링(유형, 위치, 검색)에 따라 결과에 제대로 업데이트 되지 않는 버그 수정

### DIFF
--- a/src/components/Common/ui/Button/index.tsx
+++ b/src/components/Common/ui/Button/index.tsx
@@ -6,7 +6,7 @@ type ButtonProps = {
   textColor?: string;
   backgroundColor?: string;
   disabled?: boolean;
-  onClick: () => void;
+  onClick: React.MouseEventHandler<HTMLButtonElement>;
 };
 
 export default function Button({

--- a/src/components/MyPage/MyTradeCard/index.tsx
+++ b/src/components/MyPage/MyTradeCard/index.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import Button from '@/components/Common/ui/Button';
 import { MyTradeHouseType } from '@/types/Board/tradeType';
 import { getDealStateName, getRentalName } from '@/utils/utils';
@@ -5,13 +6,14 @@ import styles from './styles.module.scss';
 
 type MyTraeCardProps = {
   tradeItem: MyTradeHouseType;
-  onClickButton: () => void;
+  onClickButton: React.MouseEventHandler<HTMLButtonElement>;
 };
 
 export default function MyTradeCard({
-  tradeItem: { rentalType, imageUrl, title, city, dealState },
+  tradeItem: { rentalType, imageUrl, title, city, dealState, houseId },
   onClickButton,
 }: MyTraeCardProps) {
+  const navigate = useNavigate();
   const getButtonStyle = (state: 'APPLYING' | 'ONGOING' | 'COMPLETED') => {
     switch (state) {
       case 'APPLYING':
@@ -41,7 +43,10 @@ export default function MyTradeCard({
   };
 
   return (
-    <tr className={styles.tradeCardWrapper}>
+    <tr
+      className={styles.tradeCardWrapper}
+      onClick={() => navigate(`/trade/trade_board/${houseId}`)}
+    >
       <td>{getRentalName(rentalType)}</td>
       <td>
         <img className={styles.image} src={imageUrl} alt="tradeImage" />

--- a/src/components/MyPage/MyTradeCard/styles.module.scss
+++ b/src/components/MyPage/MyTradeCard/styles.module.scss
@@ -1,3 +1,10 @@
+.tradeCardWrapper {
+  cursor: pointer;
+  &:hover {
+    opacity: 0.8;
+  }
+}
+
 .image {
   width: 10rem;
   height: 7.5rem;

--- a/src/components/Trade/Info/index.tsx
+++ b/src/components/Trade/Info/index.tsx
@@ -26,10 +26,10 @@ function TradeBoardInfo({ info }: TradeBoardInfoProps) {
           용도 <p>{info?.purpose}</p>
         </div>
         <div>
-          준공연도 <p>{dayjs(info?.createdDate).format('YYYY.MM.DD')}</p>
+          준공연도 <p>{dayjs(info?.createdDate).format('YYYY')}년</p>
         </div>
         <div>
-          층수 <p>{info?.floorNum}</p>
+          층수 <p>{info?.floorNum === 0 ? '-' : `${info?.floorNum}층`}</p>
         </div>
       </article>
       <article>
@@ -37,7 +37,8 @@ function TradeBoardInfo({ info }: TradeBoardInfoProps) {
         <div>
           가격{' '}
           <p>
-            {getRentalName(info?.rentalType || '')} {info?.price}만원
+            {info?.rentalType && getRentalName(info?.rentalType)} {info?.price}
+            만원
           </p>
         </div>
         <div>

--- a/src/components/Trade/Info/index.tsx
+++ b/src/components/Trade/Info/index.tsx
@@ -44,9 +44,11 @@ function TradeBoardInfo({ info }: TradeBoardInfoProps) {
         <div>
           전화번호 <p>{info?.contact}</p>
         </div>
-        <div>
-          공인중개사명 <p>{info?.agentName !== '' ? info?.agentName : 'X'}</p>
-        </div>
+        {info?.userType === 'AGENT' && (
+          <div>
+            공인중개사명 <p>{info?.agentName !== '' ? info?.agentName : 'X'}</p>
+          </div>
+        )}
       </article>
     </section>
   );

--- a/src/components/Trade/Quill/index.tsx
+++ b/src/components/Trade/Quill/index.tsx
@@ -57,8 +57,14 @@ export default function TradeQuill({
   const onPost = async () => {
     const imageUrls = [thumbnail, ...getImageUrls(form.code)];
 
+    const extractedYear = form.createdDate.match(/\d{4}/);
+    const createdDate = extractedYear ? extractedYear[0] : '2002';
+
     const newForm = {
       ...form,
+      contact: form.contact.replace(/\-/g, ''),
+      size: form.size.replace(/m2/g, ''),
+      createdDate,
       imageUrls,
     };
 
@@ -76,8 +82,14 @@ export default function TradeQuill({
   const onUpdate = async () => {
     const imageUrls = [thumbnail, ...getImageUrls(form.code)];
 
+    const extractedYear = form.createdDate.match(/\d{4}/);
+    const createdDate = extractedYear ? extractedYear[0] : '2002';
+
     const newForm = {
       ...form,
+      contact: form.contact.replace(/\-/g, ''),
+      size: form.size.replace(/m2/g, ''),
+      createdDate,
       imageUrls,
     };
 

--- a/src/pages/Mypage/trade/myself/index.tsx
+++ b/src/pages/Mypage/trade/myself/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import Loading from '@/components/Common/Loading';
 import NoPosts from '@/components/Common/NoPosts';
@@ -92,24 +92,26 @@ export default function MyselfPage() {
                 </td>
               </tr>
             )}
-            {myHouseData && myHouseData?.data.content.length > 0 ? (
-              myHouseData?.data.content.map((item, index) => (
-                <MyTradeCard
-                  key={index}
-                  tradeItem={item}
-                  onClickButton={() => {
-                    setClickedHouseId(item.houseId);
-                    setModal(true);
-                  }}
-                />
-              ))
-            ) : (
-              <tr style={{ backgroundColor: '#f8fafb' }}>
-                <td colSpan={5}>
-                  <NoPosts text="관리 중인 매물이 없어요." />
-                </td>
-              </tr>
-            )}
+            {myHouseData &&
+              (myHouseData?.data.content.length > 0 ? (
+                myHouseData?.data.content.map((item, index) => (
+                  <MyTradeCard
+                    key={index}
+                    tradeItem={item}
+                    onClickButton={(e: React.MouseEvent<HTMLButtonElement>) => {
+                      e.stopPropagation();
+                      setClickedHouseId(item.houseId);
+                      setModal(true);
+                    }}
+                  />
+                ))
+              ) : (
+                <tr style={{ backgroundColor: '#f8fafb' }}>
+                  <td colSpan={5}>
+                    <NoPosts text="관리 중인 매물이 없어요." />
+                  </td>
+                </tr>
+              ))}
           </tbody>
         </table>
         {myHouseData && myHouseData.data.content.length > 0 && (

--- a/src/pages/Mypage/trade/myself/index.tsx
+++ b/src/pages/Mypage/trade/myself/index.tsx
@@ -38,7 +38,7 @@ export default function MyselfPage() {
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     refetch();
-    setCurrentPage(0);
+    setCurrentPage(1);
     setSearch('');
   };
   return (

--- a/src/pages/Mypage/trade/myself/index.tsx
+++ b/src/pages/Mypage/trade/myself/index.tsx
@@ -33,7 +33,7 @@ export default function MyselfPage() {
     isLoading,
   } = useQuery<
     ApiResponseWithDataType<BoardPageType<MyTradeHouseType> & { count: Count }>
-  >([QueryKeys.MY_HOUSES], () => fetchMyHouseList(currentPage));
+  >([QueryKeys.MY_HOUSES, currentPage], () => fetchMyHouseList(currentPage));
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/src/pages/Trade/Board/index.tsx
+++ b/src/pages/Trade/Board/index.tsx
@@ -19,7 +19,7 @@ import 'swiper/css/navigation';
 import { TradeBoardDetailType } from '@/types/Board/tradeType';
 import { DeleteHouseAPI } from '@/apis/houses';
 import userStore from '@/store/userStore';
-import { getMoveInType, getRentalName, getUserType } from '@/utils/utils';
+import { getMoveInType, getUserType } from '@/utils/utils';
 import { ApiResponseWithDataType } from '@/types/apiResponseType';
 import { opacityVariants } from '@/constants/variants';
 import styles from './styles.module.scss';
@@ -76,8 +76,15 @@ export default function TradeBoardPage() {
       <div className={styles.title}>
         <div className={styles.innerTitle}>
           <ul className={styles.categoryList}>
-            <li>{getRentalName(data?.data.rentalType || 'JEONSE')}</li>
-            <li>{getMoveInType(data?.data.isCompleted || false)}</li>
+            <li
+              className={
+                data?.data.isCompleted
+                  ? styles.isCompletedTrade
+                  : styles.isNotCompletedTrade
+              }
+            >
+              {getMoveInType(data?.data.isCompleted || false)}
+            </li>
             <li
               className={
                 data?.data.userType === 'AGENT'

--- a/src/pages/Trade/Board/index.tsx
+++ b/src/pages/Trade/Board/index.tsx
@@ -162,7 +162,7 @@ export default function TradeBoardPage() {
             <span>매물 특징</span>
             <ul>
               {data?.data.recommendedTagName.map((tag) => (
-                <div>{tag}</div>
+                <div key={tag}>{tag}</div>
               ))}
             </ul>
           </article>

--- a/src/pages/Trade/Board/styles.module.scss
+++ b/src/pages/Trade/Board/styles.module.scss
@@ -141,10 +141,16 @@
     font-size: 1.375rem;
     padding: 0.5rem 1rem;
     line-height: normal;
-    border: 1px solid var(--main-color);
-    background-color: var(--main-color);
     color: white;
     border-radius: 24px;
+  }
+  & > .isCompletedTrade {
+    border: 1px solid black;
+    background-color: black;
+  }
+  & > .isNotCompletedTrade {
+    border: 1px solid var(--main-color);
+    background-color: var(--main-color);
   }
   & > .userTypeAgent {
     background-color: var(--sub-color);

--- a/src/pages/Trade/Write/index.tsx
+++ b/src/pages/Trade/Write/index.tsx
@@ -27,27 +27,29 @@ export default function TradeWritePage() {
   const { state }: { state: { data: TradeBoardDetailType } } = useLocation();
 
   const [form, setForm] = useState<TradeBoardForm>({
-    rentalType: state?.data.rentalType || 'SALE',
-    city: state?.data.city || '',
-    zipCode: state?.data.zipCode || '',
-    size: state?.data.size || '',
-    purpose: state?.data.purpose || '',
-    floorNum: state?.data.floorNum || 0,
-    contact: state?.data.contact || '',
-    createdDate: state?.data.createdDate || '',
-    price: state?.data.price || 0,
-    monthlyPrice: state?.data.monthlyPrice || 0,
-    agentName: state?.data.agentName || '',
-    title: state?.data.title || '',
-    code: state?.data.code || '',
-    imageUrls: state?.data.imageUrls || [],
-    tmpYn: state?.data.tmpYn || false,
-    recommendedTag: state?.data.recommendedTag || [],
+    rentalType: state ? state.data.rentalType : 'SALE',
+    city: state ? state.data.city : '',
+    zipCode: state ? state.data.zipCode : '',
+    size: state ? state.data.size : '',
+    purpose: state ? state.data.purpose : '',
+    floorNum: state ? state.data.floorNum : 0,
+    contact: state ? state.data.contact : '',
+    createdDate: state ? state.data.createdDate : '',
+    price: state ? state.data.price : 0,
+    monthlyPrice: state ? state.data.monthlyPrice : 0,
+    agentName: state ? state.data.agentName : '',
+    title: state ? state.data.title : '',
+    code: state ? state.data.code : '',
+    imageUrls: state ? state.data.imageUrls : [],
+    tmpYn: state ? state.data.tmpYn : false,
+    recommendedTag: state ? state.data.recommendedTag : [],
   });
 
-  const [thumbnail, setThumbnail] = useState(state.data.imageUrls[0] || '');
+  const [thumbnail, setThumbnail] = useState(
+    state ? state.data.imageUrls[0] : '',
+  );
   const [thumbnailTitle, setThumbnailTitle] = useState(
-    state.data.imageUrls[0].split('/')[3] || '',
+    state ? state.data.imageUrls[0].split('/')[3] : '',
   );
   const thumbnailRef = useRef<HTMLInputElement>(null);
   // 매물특징
@@ -82,6 +84,8 @@ export default function TradeWritePage() {
       }
     }
   };
+
+  console.log(form);
 
   if (!user) return <Navigate to="/login" />;
 

--- a/src/pages/Trade/Write/index.tsx
+++ b/src/pages/Trade/Write/index.tsx
@@ -85,8 +85,6 @@ export default function TradeWritePage() {
     }
   };
 
-  console.log(form);
-
   if (!user) return <Navigate to="/login" />;
 
   return (

--- a/src/pages/Trade/index.tsx
+++ b/src/pages/Trade/index.tsx
@@ -49,21 +49,24 @@ export default function TradePage() {
     return restFetcher({ method: 'GET', path: 'houses', params });
   };
 
-  const {
-    refetch: fetchBoard,
-    isLoading: isBoardLoading,
-    isInitialLoading: isMoreBoardLoading,
-  } = useQuery<ApiResponseWithDataType<TradeBoardPageType>>(
-    [QueryKeys.TRADE_BOARD, currentPage],
-    () => fetchBoardList(currentPage),
-    {
-      onSuccess: (response) => {
-        setBoardListData((prev) => [...prev, ...response.data.content]);
-        setIsLastPage(response.data.last);
-      },
-      staleTime: 0,
+  const { refetch: fetchBoard, isLoading: isBoardLoading } = useQuery<
+    ApiResponseWithDataType<TradeBoardPageType>
+  >([QueryKeys.TRADE_BOARD], () => fetchBoardList(), {
+    onSuccess: (response) => {
+      setBoardListData(response.data.content);
+      setIsLastPage(response.data.last);
     },
-  );
+  });
+  const { isInitialLoading: isMoreBoardLoading } = useQuery<
+    ApiResponseWithDataType<TradeBoardPageType>
+  >([QueryKeys.TRADE_BOARD, currentPage], () => fetchBoardList(currentPage), {
+    enabled: currentPage !== 0,
+    onSuccess: (response) => {
+      setBoardListData((prev) => [...prev, ...response.data.content]);
+      setIsLastPage(response.data.last);
+    },
+    staleTime: 0,
+  });
 
   const handleMoreBoards = () => {
     if (!isLastPage) {

--- a/src/types/Board/boardType.ts
+++ b/src/types/Board/boardType.ts
@@ -42,14 +42,3 @@ export type CommentType = {
   content: string;
   createdAt: Date;
 };
-
-export type CategoryType =
-  | 'TREND'
-  | 'REVIEW'
-  | 'INTERIOR'
-  | 'ESTATE'
-  | 'REAL_ESTATE'
-  | 'QUESTION'
-  | 'DAILY';
-
-export type PrefixCategoryType = 'DEFAULT' | 'ADVERTISEMENT';

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,5 +1,4 @@
 import axios from 'axios';
-import { CategoryType, PrefixCategoryType } from '@/types/Board/boardType';
 import {
   DealStateType,
   RecommendedTagType,
@@ -14,7 +13,7 @@ export const setInterceptor = (token: string) => {
   return true;
 };
 
-export const getCategoryName = (category: CategoryType) => {
+export const getCategoryName = (category: string) => {
   switch (category) {
     case 'TREND':
       return '트렌드';
@@ -35,7 +34,7 @@ export const getCategoryName = (category: CategoryType) => {
   }
 };
 
-export const getPrefixCategoryName = (category: PrefixCategoryType) => {
+export const getPrefixCategoryName = (category: string) => {
   switch (category) {
     case 'DEFAULT':
       return 'free_board';

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -142,6 +142,7 @@ export const checkBeforeTradePost = (
     contact,
     agentName,
     size,
+    floorNum,
     createdDate,
     purpose,
     title,
@@ -182,6 +183,10 @@ export const checkBeforeTradePost = (
   }
   if (size === '') {
     alert('평수를 입력해주세요.');
+    return false;
+  }
+  if (floorNum < 0) {
+    alert('1층 이상의 값만 작성해주세요.');
     return false;
   }
   if (createdDate === '') {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -100,7 +100,7 @@ export const getUserType = (userType: UserType) => {
 
 // 입주가능, 입주불가 구분 함수
 export const getMoveInType = (isCompleted: boolean) => {
-  return isCompleted ? '입주불가' : '입주가능';
+  return isCompleted ? '거래완료' : '입주가능';
 };
 
 export const checkBeforePost = (


### PR DESCRIPTION
## 📖 개요
빈집거래 페이지에서 상단 필터링 (유형, 지역, 검색어) 적용 시 화면에 반영되지 않는 버그 해결

## 💻 작업사항

- 초기값을 fetch하여 state에 setState하는 useQuery와 다음 페이지의 내용을 기존 state 배열에 업데이트하는 useQuery를 분리 (예전 코드로 롤백)

## 💡 작성한 이슈 외에 작업한 사항

- 빈집거래 게시글 작성 페이지 리팩토링 (유효성 검사 및 대체 텍스트 추가)
- 공인중개사 아닐 시 공인중개사 정보 표기하지 않도록 수정
- 게시글 상세 페이지에 상단 태그값에서 매물유형 정보 표기하지 않도록 수정
- 게시글 상세 페이지에서 상단 태그값에 거래완료 게시글에 대한 표기 및 스타일링 수정
- 마이페이지에서 내 매물 관리 페이지의 page값 초기값 수정 (기존 0이었는데 1로 수정)
- 마이페이지에서 내 매물 관리 페이지의 페이지네이션 값 캐싱되어 화면에 업데이트 되지 않는 버그 수정
- 마이페이지에서 내 매물 관리 페이지의 게시글 클릭 시 게시글 상세 페이지로 이동되도록 구현

## ✔️ check list

- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
