### PR TITLE
fix: 빈집거래 게시글 상태변경 시 에러 핸들링 처리

### DIFF
--- a/src/apis/houses.ts
+++ b/src/apis/houses.ts
@@ -30,6 +30,7 @@ export const PutHouseStatusAPI = async (
     return response.data;
   } catch (error) {
     const err = error as AxiosError<ApiResponseType>;
+    alert(err.response?.data.message);
     return Promise.reject(err);
   }
 };

--- a/src/components/MyPage/DealStateModal/index.tsx
+++ b/src/components/MyPage/DealStateModal/index.tsx
@@ -78,14 +78,18 @@ export default function DealStateModal({
     const score = clickedRating.filter(Boolean).length;
     if (score === 0 || nowDate === '날짜' || contact === '') {
       alert('필수 항목을 입력해주세요.');
-      return 0;
+      return;
+    }
+    if (!contact.match(/(\d{2,3}-\d{3,4}-\d{4})$/g)) {
+      alert('전화번호 형식이 맞지 않습니다.');
+      return;
     }
     const form: HouseStatusType = {
       score,
       review,
       nickName,
       age: age === '구매자 연령' ? '' : age,
-      contact,
+      contact: contact.replace(/\-/g, ''),
       dealDate: nowDate,
     };
     const response = await PutHouseStatusAPI(form, clickedHouseId);


### PR DESCRIPTION
## 📖 개요
빈집거래 게시글 상태변경 시 구매자 주말내집 닉네임 에러 핸들링 처리

## 💻 작업사항

- 빈집거래 상태 변경 시 존재하지 않는 아이디일 경우 서버에서 던져주는 에러메시지 알림
- 빈집거래 상태 변경 시 전화번호 형식 처리 및 유효성 검사 추가

## 💡 작성한 이슈 외에 작업한 사항

-

## ✔️ check list

- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
