### PR TITLE
Fix/#208 커뮤니티 페이지에서 게시글 클릭 시, 게시글 상세 페이지로 이동 안되는 버그 수정

### DIFF
--- a/src/pages/Community/Board/index.tsx
+++ b/src/pages/Community/Board/index.tsx
@@ -181,7 +181,7 @@ export default function CommunityBoardPage() {
                 key={content.boardId}
                 boardId={content.boardId}
                 category={content.category}
-                prefixCategory={category || ''}
+                prefixCategory={content.prefixCategory}
                 title={content.title}
                 oneLineContent={content.oneLineContent}
                 imageUrl={content.imageUrl}


### PR DESCRIPTION
## 💻 작업사항

- src/pages/Community/Board/index.tsx 에서 `<CommunityBoard/>` 컴포넌트 props인 prefixCategory 값을 잘못 전달하고 있었음.
따라서, 수정해서 올바른 props 값을 넘겨줘서 해결

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
