### PR TITLE
Fix/#226 스크랩 캐싱 안되는 부분 추가 구현

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -1,20 +1,20 @@
 import { lazy } from 'react';
 import { RouteObject } from 'react-router-dom';
 import GlobalLayout from '@/pages/_layout';
-import MyPage from './pages/Mypage';
-import MyCommentsPage from './pages/Mypage/community/comments';
+import MyPage from './pages/MyPage';
+import MyCommentsPage from './pages/MyPage/community/comments';
 
-import MyLikesPage from './pages/Mypage/community/likes';
-import MyWritePage from './pages/Mypage/community/write';
-import MyHomePage from './pages/Mypage/home';
-import MySettingsPage from './pages/Mypage/setting';
-import CertificateMember from './pages/Mypage/setting/CertificateMember';
-import EditMember from './pages/Mypage/setting/EditMember';
-import EditPassword from './pages/Mypage/setting/EditPassword';
-import WithdrawalFromMembership from './pages/Mypage/setting/WithdrawalFromMembership';
-import MySelfPage from './pages/Mypage/trade/myself';
-import MySavesPage from './pages/Mypage/trade/saves';
-import MyScrapPage from './pages/Mypage/trade/scrap';
+import MyLikesPage from './pages/MyPage/community/likes';
+import MyWritePage from './pages/MyPage/community/write';
+import MyHomePage from './pages/MyPage/home';
+import MySettingsPage from './pages/MyPage/setting';
+import CertificateMember from './pages/MyPage/setting/CertificateMember';
+import EditMember from './pages/MyPage/setting/EditMember';
+import EditPassword from './pages/MyPage/setting/EditPassword';
+import WithdrawalFromMembership from './pages/MyPage/setting/WithdrawalFromMembership';
+import MySelfPage from './pages/MyPage/trade/myself';
+import MySavesPage from './pages/MyPage/trade/saves';
+import MyScrapPage from './pages/MyPage/trade/scrap';
 
 const MainPage = lazy(() => import('@/pages/Main'));
 const LoginPage = lazy(() => import('@/pages/Login'));
@@ -43,7 +43,7 @@ export const routes: RouteObject[] = [
       { path: 'signup', element: <SignUpPage /> },
       { path: 'agentSignup', element: <AgentSignUpPage /> },
       {
-        path: 'mypage',
+        path: 'myPage',
         element: <MyPage />,
         children: [
           {

--- a/src/components/Trade/ScrapIcon/index.tsx
+++ b/src/components/Trade/ScrapIcon/index.tsx
@@ -34,6 +34,11 @@ function Scrap({ isScraped, boardId }: ScrapProps) {
 
       return { previousScrapData };
     },
+    onSuccess: async () => {
+      await queryClient.refetchQueries({
+        queryKey: [QueryKeys.MY_SCRAPS],
+      });
+    },
     onError: (error, newData, context) => {
       // 캐시를 저장된 값으로 롤백
       queryClient.setQueriesData([QueryKeys.TRADE_BOARD, boardId], {

--- a/src/pages/Mypage/home/index.tsx
+++ b/src/pages/Mypage/home/index.tsx
@@ -24,7 +24,7 @@ function MyHomePage() {
 
   const { data: myBoardListData } = useQuery<
     ApiResponseWithDataType<BoardPageType<myBoardType>>
-  >([QueryKeys.MINE, QueryKeys.COMMUNITY_BOARD], () =>
+  >([QueryKeys.COMMUNITY_BOARD, QueryKeys.MINE], () =>
     restFetcher({
       method: 'GET',
       path: 'boards/my',
@@ -54,7 +54,7 @@ function MyHomePage() {
 
   const { data: myScrapBoardListData } = useQuery<
     ApiResponseWithDataType<BoardPageType<TradeBoardType>>
-  >([QueryKeys.MINE, QueryKeys.TRADE_BOARD], () =>
+  >([QueryKeys.MY_SCRAPS, QueryKeys.MINE, QueryKeys.TRADE_BOARD], () =>
     restFetcher({
       method: 'GET',
       path: 'houses/scrap',

--- a/src/pages/Mypage/trade/scrap/index.tsx
+++ b/src/pages/Mypage/trade/scrap/index.tsx
@@ -20,7 +20,13 @@ function MyScrapPage() {
   const [filter, setFilter] = useState<ScrapFilterType>(INITIAL_FILTER);
   const { data: scrapBoardListData, isLoading: isScrapBoardListData } =
     useQuery<ApiResponseWithDataType<BoardPageType<TradeBoardType>>>(
-      [QueryKeys.TRADE_BOARD, QueryKeys.MINE, currentPage, filter],
+      [
+        QueryKeys.MY_SCRAPS,
+        QueryKeys.TRADE_BOARD,
+        QueryKeys.MINE,
+        currentPage,
+        filter,
+      ],
       () =>
         restFetcher({
           method: 'GET',

--- a/src/queryClient.ts
+++ b/src/queryClient.ts
@@ -63,6 +63,7 @@ export const QueryKeys = {
   COMMENT: 'COMMENT',
   MINE: 'MINE',
   LIKE: 'LIKE',
+  MY_SCRAPS: 'MY_SCRAPS',
   MY_HOUSES: 'MY_HOUSES',
   MY_SAVES: 'MY_SAVES',
   MY_COMMENTS: 'MY_COMMENTS',


### PR DESCRIPTION
## 📖 개요
- 스크랩을 누르면 관련된 캐싱 데이터들 동기화 하기

## 💻 작업사항
- Querykey 추가
- refechQueires 사용해 데이터 동기화
- route 경로 대소문자 변경 Mypage -> MyPage

## ✔️ check list

- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
