### PR TITLE
Fix/#242 회원가입 - 닉네임 중복확인, 이메일, 전화번호 인증 시 안내

### DIFF
--- a/src/components/MyPage/MySetting/EditInfo/EditEmailInfo/index.tsx
+++ b/src/components/MyPage/MySetting/EditInfo/EditEmailInfo/index.tsx
@@ -140,7 +140,7 @@ export default function EditEmailInfo({
               !/^([\w\.\_\-])*[a-zA-Z0-9]+([\w\.\_\-])*([a-zA-Z0-9])+([\w\.\_\-])+@([a-zA-Z0-9]+\.)+[a-zA-Z0-9]{2,8}$/g.test(
                 watch('email'),
               ) || isCheckEmail
-                ? styles.buttonStyleDisabled
+                ? styles.Disabled
                 : styles.buttonStyleActive
             }
             disabled={

--- a/src/components/MyPage/MySetting/EditInfo/EditEmailInfo/styles.module.scss
+++ b/src/components/MyPage/MySetting/EditInfo/EditEmailInfo/styles.module.scss
@@ -63,11 +63,11 @@
   &:hover {
     opacity: 0.8;
   }
-}
-.buttonStyle:disabled {
-  cursor: auto;
-  &:hover {
-    opacity: 1;
+  &:disabled {
+    cursor: not-allowed;
+    &:hover {
+      opacity: 1;
+    }
   }
 }
 

--- a/src/components/MyPage/MySetting/EditInfo/EditNicknameInfo/styles.module.scss
+++ b/src/components/MyPage/MySetting/EditInfo/EditNicknameInfo/styles.module.scss
@@ -61,11 +61,11 @@
   &:hover {
     opacity: 0.8;
   }
-}
-.buttonStyle:disabled {
-  cursor: auto;
-  &:hover {
-    opacity: 1;
+  &:disabled {
+    cursor: not-allowed;
+    &:hover {
+      opacity: 1;
+    }
   }
 }
 

--- a/src/components/MyPage/MySetting/EditInfo/EditPhoneInfo/styles.module.scss
+++ b/src/components/MyPage/MySetting/EditInfo/EditPhoneInfo/styles.module.scss
@@ -63,11 +63,11 @@
   &:hover {
     opacity: 0.8;
   }
-}
-.buttonStyle:disabled {
-  cursor: auto;
-  &:hover {
-    opacity: 1;
+  &:disabled {
+    cursor: not-allowed;
+    &:hover {
+      opacity: 1;
+    }
   }
 }
 

--- a/src/pages/SignUp/AgentSignUp/index.tsx
+++ b/src/pages/SignUp/AgentSignUp/index.tsx
@@ -636,11 +636,19 @@ export default function AgentSignUpPage() {
               인증요청
             </button>
           </div>
-          <p className={signUpStyles.errorMessage}>
+          <p
+            className={
+              isCheckEmail
+                ? signUpStyles.correctMessage
+                : signUpStyles.errorMessage
+            }
+          >
+            {isCheckEmail && '인증코드가 발송되었습니다.'}
             {errors.company_email && errors.company_email.message}
             {!errors.company_email && emailErrMessage && emailErrMessage}
           </p>
         </div>
+        {/* 이메일 인증 */}
         {isCheckEmail && (
           <div className={signUpStyles.inputContainer}>
             <label htmlFor="email_code">인증코드</label>
@@ -884,7 +892,14 @@ export default function AgentSignUpPage() {
               인증요청
             </button>
           </div>
-          <p className={signUpStyles.errorMessage}>
+          <p
+            className={
+              isCheckNum
+                ? signUpStyles.correctMessage
+                : signUpStyles.errorMessage
+            }
+          >
+            {isCheckNum && '인증문자가 발송되었습니다.'}
             {errors.phone_num && errors.phone_num.message}
             {!errors.phone_num && phoneErrMessage && phoneErrMessage}
           </p>

--- a/src/pages/SignUp/AgentSignUp/index.tsx
+++ b/src/pages/SignUp/AgentSignUp/index.tsx
@@ -572,7 +572,7 @@ export default function AgentSignUpPage() {
             />
             <button
               type="button"
-              className={signUpStyles.buttonStyle}
+              className={signUpStyles.buttonStyleActive}
               onClick={() => {
                 setIsPostcodeOpen((pre) => !pre);
               }}
@@ -622,11 +622,16 @@ export default function AgentSignUpPage() {
               className={
                 /^([\w\.\_\-])*[a-zA-Z0-9]+([\w\.\_\-])*([a-zA-Z0-9])+([\w\.\_\-])+@([a-zA-Z0-9]+\.)+[a-zA-Z0-9]{2,8}$/g.test(
                   watch('company_email'),
-                )
+                ) && !isCheckEmail
                   ? signUpStyles.buttonStyleActive
                   : signUpStyles.buttonStyle
               }
               onClick={onSendEmail}
+              disabled={
+                !/^([\w\.\_\-])*[a-zA-Z0-9]+([\w\.\_\-])*([a-zA-Z0-9])+([\w\.\_\-])+@([a-zA-Z0-9]+\.)+[a-zA-Z0-9]{2,8}$/g.test(
+                  watch('company_email'),
+                ) || isCheckEmail
+              }
             >
               인증요청
             </button>
@@ -656,11 +661,16 @@ export default function AgentSignUpPage() {
               <button
                 type="button"
                 className={
-                  /^(?=.*[0-9])[0-9]{4}$/g.test(watch('email_code'))
+                  /^(?=.*[0-9])[0-9]{4}$/g.test(watch('email_code')) &&
+                  !emailCheck
                     ? signUpStyles.buttonStyleActive
                     : signUpStyles.buttonStyle
                 }
                 onClick={onCheckEmail}
+                disabled={
+                  !/^(?=.*[0-9])[0-9]{4}$/g.test(watch('email_code')) ||
+                  emailCheck
+                }
               >
                 확인
               </button>
@@ -702,11 +712,17 @@ export default function AgentSignUpPage() {
             <button
               type="button"
               className={
-                /^(?=.*[A-Za-z])[A-Za-z_0-9]{4,20}$/g.test(watch('userName'))
+                /^(?=.*[A-Za-z])[A-Za-z_0-9]{4,20}$/g.test(watch('userName')) &&
+                !idCheck
                   ? signUpStyles.buttonStyleActive
                   : signUpStyles.buttonStyle
               }
               onClick={idCheckHandler}
+              disabled={
+                !/^(?=.*[A-Za-z])[A-Za-z_0-9]{4,20}$/g.test(
+                  watch('userName'),
+                ) || idCheck
+              }
             >
               중복확인
             </button>
@@ -809,11 +825,16 @@ export default function AgentSignUpPage() {
               className={
                 /^(?=.*[a-zA-Z0-9가-힣])[A-Za-z0-9가-힣]{1,20}$/g.test(
                   watch('nick_name'),
-                )
+                ) && !nicknameCheck
                   ? signUpStyles.buttonStyleActive
                   : signUpStyles.buttonStyle
               }
               onClick={nicknameCheckHandler}
+              disabled={
+                !/^(?=.*[a-zA-Z0-9가-힣])[A-Za-z0-9가-힣]{1,20}$/g.test(
+                  watch('nick_name'),
+                ) || nicknameCheck
+              }
             >
               중복확인
             </button>
@@ -849,11 +870,16 @@ export default function AgentSignUpPage() {
             <button
               type="button"
               className={
-                /^01(?:0|1|[6-9])[0-9]{7,8}$/g.test(watch('phone_num'))
+                /^01(?:0|1|[6-9])[0-9]{7,8}$/g.test(watch('phone_num')) &&
+                !isCheckNum
                   ? signUpStyles.buttonStyleActive
                   : signUpStyles.buttonStyle
               }
               onClick={onSendSMS}
+              disabled={
+                !/^01(?:0|1|[6-9])[0-9]{7,8}$/g.test(watch('phone_num')) ||
+                isCheckNum
+              }
             >
               인증요청
             </button>
@@ -884,11 +910,16 @@ export default function AgentSignUpPage() {
               <button
                 type="button"
                 className={
-                  /^(?=.*[0-9])[0-9]{4}$/g.test(watch('phone_check'))
+                  /^(?=.*[0-9])[0-9]{4}$/g.test(watch('phone_check')) &&
+                  !phoneSMSCheck
                     ? signUpStyles.buttonStyleActive
                     : signUpStyles.buttonStyle
                 }
                 onClick={onCheckSMS}
+                disabled={
+                  !/^(?=.*[0-9])[0-9]{4}$/g.test(watch('phone_check')) ||
+                  phoneSMSCheck
+                }
               >
                 확인
               </button>

--- a/src/pages/SignUp/index.tsx
+++ b/src/pages/SignUp/index.tsx
@@ -542,7 +542,10 @@ export default function SignUpPage() {
               인증요청
             </button>
           </div>
-          <p className={styles.errorMessage}>
+          <p
+            className={isCheckNum ? styles.correctMessage : styles.errorMessage}
+          >
+            {isCheckNum && '인증문자가 발송되었습니다.'}
             {errors.phone_num && errors.phone_num.message}
             {!errors.phone_num && phoneErrMessage}
           </p>
@@ -629,7 +632,12 @@ export default function SignUpPage() {
               인증요청
             </button>
           </div>
-          <p className={styles.errorMessage}>
+          <p
+            className={
+              isCheckEmail ? styles.correctMessage : styles.errorMessage
+            }
+          >
+            {isCheckEmail && '인증코드가 발송되었습니다.'}
             {errors.email && errors.email.message}
             {!errors.email && emailErrMessage && emailErrMessage}
           </p>

--- a/src/pages/SignUp/index.tsx
+++ b/src/pages/SignUp/index.tsx
@@ -380,11 +380,17 @@ export default function SignUpPage() {
             <button
               type="button"
               className={
-                /^(?=.*[A-Za-z])[A-Za-z_0-9]{4,20}$/g.test(watch('userName'))
+                /^(?=.*[A-Za-z])[A-Za-z_0-9]{4,20}$/g.test(watch('userName')) &&
+                !idCheck
                   ? styles.buttonStyleActive
                   : styles.buttonStyle
               }
               onClick={idCheckHandler}
+              disabled={
+                !/^(?=.*[A-Za-z])[A-Za-z_0-9]{4,20}$/g.test(
+                  watch('userName'),
+                ) || idCheck
+              }
             >
               중복확인
             </button>
@@ -479,11 +485,16 @@ export default function SignUpPage() {
               className={
                 /^(?=.*[a-zA-Z0-9가-힣])[A-Za-z0-9가-힣]{1,20}$/g.test(
                   watch('nick_name'),
-                )
+                ) && !nicknameCheck
                   ? styles.buttonStyleActive
                   : styles.buttonStyle
               }
               onClick={nicknameCheckHandler}
+              disabled={
+                !/^(?=.*[a-zA-Z0-9가-힣])[A-Za-z0-9가-힣]{1,20}$/g.test(
+                  watch('nick_name'),
+                ) || nicknameCheck
+              }
             >
               중복확인
             </button>
@@ -517,11 +528,16 @@ export default function SignUpPage() {
             <button
               type="button"
               className={
-                /^01(?:0|1|[6-9])[0-9]{7,8}$/g.test(watch('phone_num'))
+                /^01(?:0|1|[6-9])[0-9]{7,8}$/g.test(watch('phone_num')) &&
+                !isCheckNum
                   ? styles.buttonStyleActive
                   : styles.buttonStyle
               }
               onClick={onSendSMS}
+              disabled={
+                !/^01(?:0|1|[6-9])[0-9]{7,8}$/g.test(watch('phone_num')) ||
+                isCheckNum
+              }
             >
               인증요청
             </button>
@@ -552,11 +568,16 @@ export default function SignUpPage() {
               <button
                 type="button"
                 className={
-                  /^(?=.*[0-9])[0-9]{4}$/g.test(watch('phone_check'))
+                  /^(?=.*[0-9])[0-9]{4}$/g.test(watch('phone_check')) &&
+                  !phoneSMSCheck
                     ? styles.buttonStyleActive
                     : styles.buttonStyle
                 }
                 onClick={onCheckSMS}
+                disabled={
+                  !/^(?=.*[0-9])[0-9]{4}$/g.test(watch('phone_check')) ||
+                  phoneSMSCheck
+                }
               >
                 확인
               </button>
@@ -594,11 +615,16 @@ export default function SignUpPage() {
               className={
                 /^([\w\.\_\-])*[a-zA-Z0-9]+([\w\.\_\-])*([a-zA-Z0-9])+([\w\.\_\-])+@([a-zA-Z0-9]+\.)+[a-zA-Z0-9]{2,8}$/g.test(
                   watch('email'),
-                )
+                ) && !isCheckEmail
                   ? styles.buttonStyleActive
                   : styles.buttonStyle
               }
               onClick={onSendEmail}
+              disabled={
+                !/^([\w\.\_\-])*[a-zA-Z0-9]+([\w\.\_\-])*([a-zA-Z0-9])+([\w\.\_\-])+@([a-zA-Z0-9]+\.)+[a-zA-Z0-9]{2,8}$/g.test(
+                  watch('email'),
+                ) || isCheckEmail
+              }
             >
               인증요청
             </button>
@@ -629,11 +655,16 @@ export default function SignUpPage() {
               <button
                 type="button"
                 className={
-                  /^(?=.*[0-9])[0-9]{4}$/g.test(watch('email_code'))
+                  /^(?=.*[0-9])[0-9]{4}$/g.test(watch('email_code')) &&
+                  !emailCheck
                     ? styles.buttonStyleActive
                     : styles.buttonStyle
                 }
                 onClick={onCheckEmail}
+                disabled={
+                  !/^(?=.*[0-9])[0-9]{4}$/g.test(watch('email_code')) ||
+                  emailCheck
+                }
               >
                 확인
               </button>

--- a/src/pages/SignUp/styles.module.scss
+++ b/src/pages/SignUp/styles.module.scss
@@ -208,6 +208,12 @@
   &:hover {
     opacity: 0.8;
   }
+  &:disabled {
+    cursor: not-allowed;
+    &:hover {
+      opacity: 1;
+    }
+  }
 }
 .buttonStyleActive {
   @extend .buttonStyle;


### PR DESCRIPTION
## 📖 개요
회원가입 페이지에서 중복확인 및 인증 요청 시 사용자에게 명시적으로 안내 메세지 표시 및 버튼 비활성화 처리

## 💻 작업사항

- 일반 회원 및 공인중개사 회원 가입 페이지에 대하여
  - 버튼 disabled 설정 및 확인이 완료된 버튼은 비활성화 처리
  - 인증코드 요청 시 요청 완료 메세지 표시

## 💡 작성한 이슈 외에 작업한 사항

- 

## ✔️ check list

- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
