### PR TITLE
Feat/#246 자유게시판 게시글 작성시 말머리 미선택해도 게시글 작성 가능하게 구현

### DIFF
--- a/src/components/Community/Board/index.tsx
+++ b/src/components/Community/Board/index.tsx
@@ -35,7 +35,9 @@ export default function CommunityBoard({
       >
         <span className={styles.title}>
           {fixed && <span className={styles.advertisement}>광고</span>}
-          <h3 className={styles.category}>[{getCategoryName(category)}]</h3>
+          {getCategoryName(category) && (
+            <h3 className={styles.category}>[{getCategoryName(category)}]</h3>
+          )}
           <h3 className={styles.titleMessage}>{title}</h3>
         </span>
         <div className={styles.contentWrapper}>

--- a/src/components/Community/Quill/index.tsx
+++ b/src/components/Community/Quill/index.tsx
@@ -144,7 +144,7 @@ export default function CommunityQuill({ queryParam }: CommunityQuillProps) {
           <select
             className={styles.categoryInput}
             name="category"
-            value={category}
+            value={category === 'EMPTY' ? '' : category}
             onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
               setCategory(e.target.value)
             }

--- a/src/components/Community/Quill/index.tsx
+++ b/src/components/Community/Quill/index.tsx
@@ -88,7 +88,9 @@ export default function CommunityQuill({ queryParam }: CommunityQuillProps) {
     const BoardForm: BoardFormType = {
       title,
       code: contents,
-      category,
+      // TODO: 말머리가 없을 경우 'EMPTY'로 처리
+      // 상수로 관리하는게 좋아보임. 백엔드 ENUM 값과 동기화 필요
+      category: category || 'EMPTY',
       imageUrls,
       prefixCategory,
       fixed: false,

--- a/src/components/Community/Quill/index.tsx
+++ b/src/components/Community/Quill/index.tsx
@@ -83,7 +83,7 @@ export default function CommunityQuill({ queryParam }: CommunityQuillProps) {
   const onPost = async () => {
     setIsProcessing(true);
     const imageUrls = [...getImageUrls(contents)];
-    if (!checkBeforePost(title, contents, category)) return;
+    if (!checkBeforePost(title, contents)) return;
 
     const BoardForm: BoardFormType = {
       title,

--- a/src/components/Introduce/Quill/index.tsx
+++ b/src/components/Introduce/Quill/index.tsx
@@ -100,7 +100,7 @@ export default function IntroduceQuill() {
   const onPost = async () => {
     setIsProcessing(true);
     const imageUrls = [thumbnail, ...getImageUrls(contents)];
-    if (!checkBeforePost(title, contents, category, imageUrls)) return;
+    if (!checkBeforePost(title, contents, imageUrls)) return;
 
     const BoardForm: BoardFormType = {
       title,

--- a/src/pages/Community/Detail/index.tsx
+++ b/src/pages/Community/Detail/index.tsx
@@ -63,8 +63,10 @@ export default function CommunityBoardDetailPage() {
       <div className={styles.title}>
         <div className={styles.innerTitle}>
           <h1>
-            [{getCategoryName(boardData?.data.category || '')}]{' '}
-            {boardData?.data.title}
+            {getCategoryName(boardData?.data.category || '') && (
+              <p>[{getCategoryName(boardData?.data.category || '')}]</p>
+            )}
+            <p>{boardData?.data.title}</p>
           </h1>
           <div>
             <p>

--- a/src/pages/Community/Detail/styles.module.scss
+++ b/src/pages/Community/Detail/styles.module.scss
@@ -22,6 +22,10 @@
   height: 100%;
   color: black;
   font-family: 'Pretendard';
+  & > h1 {
+    display: flex;
+    gap: 0.5rem;
+  }
 
   & > div {
     display: flex;

--- a/src/styles/editor.scss
+++ b/src/styles/editor.scss
@@ -63,3 +63,7 @@
   margin: 0.5rem 0;
   border-radius: 8px;
 }
+
+& a {
+  color: var(--main-color);
+}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -108,7 +108,6 @@ export const getMoveInType = (isCompleted: boolean) => {
 export const checkBeforePost = (
   title: string,
   contents: string,
-  category: string,
   imageUrl?: string[],
 ) => {
   if (title === '') {
@@ -119,10 +118,6 @@ export const checkBeforePost = (
     alert('내용을 입력해주세요.');
     return false;
   }
-  // if (category === '') {
-  //   alert('말머리를 선택해주세요.');
-  //   return false;
-  // }
   if (imageUrl && imageUrl[0] === '') {
     alert('썸네일을 등록해주세요.');
     return false;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -31,7 +31,7 @@ export const getCategoryName = (category: string) => {
     case 'DAILY':
       return '일상';
     case 'EMPTY':
-      return '전체';
+      return '';
     default:
       return '';
   }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -13,6 +13,7 @@ export const setInterceptor = (token: string) => {
   return true;
 };
 
+// TODO: 상수 관리 고민
 export const getCategoryName = (category: string) => {
   switch (category) {
     case 'TREND':
@@ -29,6 +30,8 @@ export const getCategoryName = (category: string) => {
       return '질문';
     case 'DAILY':
       return '일상';
+    case 'EMPTY':
+      return '전체';
     default:
       return '';
   }
@@ -116,10 +119,10 @@ export const checkBeforePost = (
     alert('내용을 입력해주세요.');
     return false;
   }
-  if (category === '') {
-    alert('말머리를 선택해주세요.');
-    return false;
-  }
+  // if (category === '') {
+  //   alert('말머리를 선택해주세요.');
+  //   return false;
+  // }
   if (imageUrl && imageUrl[0] === '') {
     alert('썸네일을 등록해주세요.');
     return false;


### PR DESCRIPTION
## 💻 작업사항

- 자유게시판 말머리 미 선택시, category 값 'EMPTY' 로 설정
  - 백엔드 ENUM 맞추기 위해서 'EMPTY'로 설정
- 게시판에 a태그 관련 색상 메인컬러로 변경
![image](https://github.com/ODOICHON/frontend/assets/90402926/edbfd49f-6c6f-4325-906a-a66539b80499)

## 백엔드에게 요청사항
- category 값은 백엔드에서 ENUM 값으로 관리중, 따라서 Board API 명세서에 ENUM 종류 확인 가능하도록 요청

## 기획팀이랑 상의해봐야 하는 내용
- 현재 category 미선택 시, 게시글 말머리 표시는 '[전체]'로 표기하도록 했다.
- 말머리 표시가 아예 안나오게 할지 물어보기 또는 다른 키워드로 할지
- 피그마에는 이 부분에 대한 디자인 없음
<img width="561" alt="스크린샷 2024-03-19 오후 5 11 10" src="https://github.com/ODOICHON/frontend/assets/90402926/4292eb3a-7600-4e70-a6c3-eb1a3cb5065f">

[기획팀 답변]
- 키워드 없이 제목으로 시작하기
수정 후
![image](https://github.com/ODOICHON/frontend/assets/90402926/205adfc5-571d-46b5-a938-59ab9afa1804)


## 고민사항
- 프론트에서 category 값 상수화 해서 사용하는게 좋아보인다. ( TODO 키워드로 검색해서 부분 고치기 )
- 어떤 식으로 상수화를 해서 관리할지 고민


## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
