### PR TITLE
Feat/#248 홍보, 자유 게시판 댓글 삭제 시, 모달창 띄우기

### DIFF
--- a/src/components/Board/CommentDetail/index.tsx
+++ b/src/components/Board/CommentDetail/index.tsx
@@ -10,12 +10,14 @@ type CommentDetailProps = {
   comment: CommentType;
   boardId: number;
   intro?: boolean;
+  handleDeleteComment: () => void;
 };
 
 export default function CommentDetail({
   comment,
   boardId,
   intro,
+  handleDeleteComment,
 }: CommentDetailProps) {
   const { user } = userStore();
   const queryClient = useQueryClient();
@@ -28,6 +30,7 @@ export default function CommentDetail({
     {
       onSuccess: () => {
         // TODO: 이후 소개 페이지가 아닐 시 실행할 쿼리키 등록
+        handleDeleteComment();
         return queryClient.refetchQueries([
           intro ? QueryKeys.INTRO_BOARD : QueryKeys.COMMUNITY_BOARD,
         ]);

--- a/src/components/Board/Comments/index.tsx
+++ b/src/components/Board/Comments/index.tsx
@@ -61,6 +61,11 @@ export default function Comments({
     setContent(value);
   };
 
+  const handleDeleteComment = () => {
+    handleToastMessageProps('DELETE_COMMENT_SUCCESS', handleModalClose);
+    handleModalOpen();
+  };
+
   const onClickButton = () => {
     if (!user) {
       handleToastMessageProps('LOGIN_REQUIRED_ERROR', handleModalClose, () =>
@@ -98,6 +103,7 @@ export default function Comments({
           comment={comment}
           boardId={boardId}
           intro={intro}
+          handleDeleteComment={handleDeleteComment}
         />
       ))}
       {modalState && toastMessageProps && (

--- a/src/hooks/useToastMessageType.ts
+++ b/src/hooks/useToastMessageType.ts
@@ -5,6 +5,7 @@ type ToastMessageKeyType =
   | 'POST_COMMENT_SUCCESS'
   | 'DELETE_COMMENT_SUCCESS'
   | 'POST_COMMENT_ERROR'
+  | 'DELETE_COMMENT_ERROR'
   | 'COMMENT_EMPTY_ERROR'
   | 'LOGIN_REQUIRED_ERROR'
   | 'POST_DELETE_SUCCESS'
@@ -34,6 +35,11 @@ export const TOAST_MESSAGE: ToastMessageType = {
   },
   POST_COMMENT_ERROR: {
     message: '댓글 등록에 실패했습니다.',
+    subMessage: '잠시 후 다시 시도해주세요.',
+    iconType: 'ERROR',
+  },
+  DELETE_COMMENT_ERROR: {
+    message: '댓글 삭제에 실패했습니다.',
     subMessage: '잠시 후 다시 시도해주세요.',
     iconType: 'ERROR',
   },

--- a/src/hooks/useToastMessageType.ts
+++ b/src/hooks/useToastMessageType.ts
@@ -3,6 +3,7 @@ import { ToastMessageModalProps } from '@/components/Common/ToastMessageModal';
 
 type ToastMessageKeyType =
   | 'POST_COMMENT_SUCCESS'
+  | 'DELETE_COMMENT_SUCCESS'
   | 'POST_COMMENT_ERROR'
   | 'COMMENT_EMPTY_ERROR'
   | 'LOGIN_REQUIRED_ERROR'
@@ -23,6 +24,11 @@ type ToastMessageType = {
 export const TOAST_MESSAGE: ToastMessageType = {
   POST_COMMENT_SUCCESS: {
     message: '댓글이 등록되었습니다.',
+    subMessage: undefined,
+    iconType: 'SUCCESS',
+  },
+  DELETE_COMMENT_SUCCESS: {
+    message: '댓글이 삭제되었습니다.',
     subMessage: undefined,
     iconType: 'SUCCESS',
   },


### PR DESCRIPTION
## 📖 개요
- 홍보, 자유게시판 댓글 삭제 시, 삭제되었다는 모달창 띄우기

## 💻 작업사항

- 댓글 삭제 시, 모달창에 띄어지는 상수 값 추가
- useModalState 훅에서 handleModalClose에 함수 파라미터 받도록 추가

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
