### PR TITLE
게시글 작성 시 S3 이미지 관련 기능 추가

### DIFF
--- a/src/apis/uploadS3.ts
+++ b/src/apis/uploadS3.ts
@@ -8,6 +8,7 @@ const {
   VITE_S3_SECRET_ACCESS_KEY,
   VITE_S3_BUCKET_NAME,
   VITE_S3_REGION,
+  VITE_S3_DOMAIN,
 } = import.meta.env;
 
 AWS.config.update({
@@ -19,12 +20,10 @@ const s3 = new AWS.S3();
 const bucketName = VITE_S3_BUCKET_NAME;
 
 export const uploadFile = async (file: File) => {
-  const { type, name } = file;
+  const { type } = file;
   const params = {
     Bucket: bucketName,
-    Key: `${name}/${v4().toString().replace('-', '')}.${
-      file.type.split('/')[1]
-    }`,
+    Key: `${v4().toString().replaceAll('-', '')}.${type.split('/')[1]}`,
     Body: file,
     ContentType: type,
     ACL: 'public-read',
@@ -35,4 +34,19 @@ export const uploadFile = async (file: File) => {
   } catch (err) {
     alert((err as AxiosError<ApiResponseType>).response?.data.message);
   }
+};
+
+export const deleteFile = (urls: string[]) => {
+  urls.map(async (url) => {
+    try {
+      await s3
+        .deleteObject({
+          Bucket: bucketName,
+          Key: url.split(VITE_S3_DOMAIN)[1].slice(1),
+        })
+        .promise();
+    } catch (err) {
+      console.error('이미지를 삭제하는데 실패했습니다.');
+    }
+  });
 };

--- a/src/components/Community/Board/index.tsx
+++ b/src/components/Community/Board/index.tsx
@@ -2,7 +2,6 @@ import { useNavigate } from 'react-router-dom';
 import dayjs from 'dayjs';
 import { CommunityBoardType } from '@/types/Board/communityType';
 import { getCategoryName, getPrefixCategoryName } from '@/utils/utils';
-import { THUMBNAIL_SIZE_OPTION } from '@/constants/image';
 import styles from './styles.module.scss';
 
 type CommunityBoardProps = Omit<CommunityBoardType, 'code'>;
@@ -52,7 +51,8 @@ export default function CommunityBoard({
           {imageUrl && (
             <img
               className={styles.thumbnailImage}
-              src={imageUrl + THUMBNAIL_SIZE_OPTION}
+              // src={imageUrl + THUMBNAIL_SIZE_OPTION}
+              src={imageUrl}
               alt="thumbnail"
             />
           )}

--- a/src/components/Community/Quill/index.tsx
+++ b/src/components/Community/Quill/index.tsx
@@ -9,6 +9,7 @@ import { QueryKeys, restFetcher } from '@/queryClient';
 import { BoardFormType } from '@/types/Board/boardType';
 import { CommunityBoardDetailType } from '@/types/Board/communityType';
 import getImageUrls from '@/utils/Quill/getImageUrls';
+import getNotUsedImageUrl from '@/utils/Quill/getNotUsedImageUrl';
 import { PostBoardAPI } from '@/apis/boards';
 import { deleteFile } from '@/apis/uploadS3';
 import { imageStore } from '@/store/imageStore';
@@ -93,7 +94,7 @@ export default function CommunityQuill({ queryParam }: CommunityQuillProps) {
     }
 
     const imageUrls = [...getImageUrls(contents)];
-    const notUsedImageUrls = images.filter((url) => !imageUrls.includes(url));
+    const notUsedImageUrls = getNotUsedImageUrl(images, imageUrls);
 
     const BoardForm: BoardFormType = {
       title,
@@ -134,7 +135,7 @@ export default function CommunityQuill({ queryParam }: CommunityQuillProps) {
     }
 
     const imageUrls = [...getImageUrls(contents)];
-    const notUsedImageUrls = images.filter((url) => !imageUrls.includes(url));
+    const notUsedImageUrls = getNotUsedImageUrl(images, imageUrls);
 
     const BoardForm: BoardFormType = {
       title,

--- a/src/components/Community/Quill/index.tsx
+++ b/src/components/Community/Quill/index.tsx
@@ -35,6 +35,7 @@ export default function CommunityQuill({ queryParam }: CommunityQuillProps) {
   const { toastMessageProps, handleToastMessageProps } = useToastMessageType();
 
   const QuillRef = useRef<ReactQuill>();
+  const latestImages = useRef(images);
 
   const [title, setTitle] = useState(boardData ? boardData.title : '');
   const [contents, setContents] = useState('');
@@ -138,13 +139,20 @@ export default function CommunityQuill({ queryParam }: CommunityQuillProps) {
   };
 
   useEffect(() => {
+    latestImages.current = images;
+  }, [images]);
+
+  useEffect(() => {
     // 개발모드에선 StricMode 때문에 같은글이 두번 넣어짐. StrictMode를 해제하고 테스트하자
     if (boardData) {
       QuillRef.current
         ?.getEditor()
         .clipboard.dangerouslyPasteHTML(0, boardData.code);
     }
-    return () => resetImages();
+    return () => {
+      deleteFile(latestImages.current);
+      resetImages();
+    };
   }, []);
 
   return (

--- a/src/components/Introduce/Quill/index.tsx
+++ b/src/components/Introduce/Quill/index.tsx
@@ -35,6 +35,7 @@ export default function IntroduceQuill() {
 
   const QuillRef = useRef<ReactQuill>();
   const thumbnailRef = useRef<HTMLInputElement>(null);
+  const imagesRef = useRef(images);
 
   const [title, setTitle] = useState(boardData ? boardData.title : '');
   const [contents, setContents] = useState('');
@@ -163,13 +164,20 @@ export default function IntroduceQuill() {
   };
 
   useEffect(() => {
+    imagesRef.current = images;
+  }, [images]);
+
+  useEffect(() => {
     // 개발모드에선 StricMode 때문에 같은글이 두번 넣어짐. StrictMode를 해제하고 테스트하자
     if (boardData) {
       QuillRef.current
         ?.getEditor()
         .clipboard.dangerouslyPasteHTML(0, boardData.code);
     }
-    return () => resetImages();
+    return () => {
+      deleteFile(imagesRef.current);
+      resetImages();
+    };
   }, []);
 
   return (

--- a/src/components/Introduce/Quill/index.tsx
+++ b/src/components/Introduce/Quill/index.tsx
@@ -10,6 +10,7 @@ import { QueryKeys, restFetcher } from '@/queryClient';
 import { BoardFormType } from '@/types/Board/boardType';
 import { IntroBoardDetailType } from '@/types/Board/introType';
 import getImageUrls from '@/utils/Quill/getImageUrls';
+import getNotUsedImageUrl from '@/utils/Quill/getNotUsedImageUrl';
 import { PostBoardAPI } from '@/apis/boards';
 import { deleteFile, uploadFile } from '@/apis/uploadS3';
 import { imageStore } from '@/store/imageStore';
@@ -112,7 +113,7 @@ export default function IntroduceQuill() {
       return;
     }
 
-    const notUsedImageUrls = images.filter((url) => !imageUrls.includes(url));
+    const notUsedImageUrls = getNotUsedImageUrl(images, imageUrls);
 
     const BoardForm: BoardFormType = {
       title,
@@ -150,7 +151,7 @@ export default function IntroduceQuill() {
       return;
     }
 
-    const notUsedImageUrls = images.filter((url) => !imageUrls.includes(url));
+    const notUsedImageUrls = getNotUsedImageUrl(images, imageUrls);
 
     const BoardForm: BoardFormType = {
       title,

--- a/src/components/Introduce/ReviewBoard/index.tsx
+++ b/src/components/Introduce/ReviewBoard/index.tsx
@@ -1,6 +1,5 @@
 import { useNavigate } from 'react-router-dom';
 import { IntroBoardType } from '@/types/Board/introType';
-import { THUMBNAIL_SIZE_OPTION } from '@/constants/image';
 import styles from './styles.module.scss';
 
 type ReviewBoardProps = IntroBoardType;
@@ -13,7 +12,8 @@ export default function ReviewBoard(props: ReviewBoardProps) {
       className={styles.wrapper}
       onClick={() => navigate(`/intro_board/${props.boardId}`)}
     >
-      <img src={props.imageUrl + THUMBNAIL_SIZE_OPTION} alt="backgroundImg" />
+      {/* <img src={props.imageUrl + THUMBNAIL_SIZE_OPTION} alt="backgroundImg" /> */}
+      <img src={props.imageUrl} alt="backgroundImg" />
       <h3>{props.title}</h3>
       <p>{props.oneLineContent}...</p>
     </div>

--- a/src/components/Introduce/TrendBoard/index.tsx
+++ b/src/components/Introduce/TrendBoard/index.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AnimatePresence, motion } from 'framer-motion';
 import { IntroBoardType } from '@/types/Board/introType';
-import { THUMBNAIL_SIZE_OPTION } from '@/constants/image';
 import { updownVariants } from '@/constants/variants';
 import styles from './styles.module.scss';
 
@@ -17,12 +16,19 @@ export default function TrendBoard(props: TrendBoardProps) {
       onClick={() => navigate(`/intro_board/${props.boardId}`)}
       onMouseOver={() => setIsMouseOver(true)}
       onMouseLeave={() => setIsMouseOver(false)}
+      // style={{
+      //   backgroundImage: isMouseOver
+      //     ? `linear-gradient(rgba(0, 0, 0, 0.35), rgba(0, 0, 0, 0.35)),
+      // url('${props.imageUrl + THUMBNAIL_SIZE_OPTION}')`
+      //     : `linear-gradient(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.2)),
+      // url('${props.imageUrl + THUMBNAIL_SIZE_OPTION}')`,
+      // }}
       style={{
         backgroundImage: isMouseOver
           ? `linear-gradient(rgba(0, 0, 0, 0.35), rgba(0, 0, 0, 0.35)),
-      url('${props.imageUrl + THUMBNAIL_SIZE_OPTION}')`
+      url('${props.imageUrl}')`
           : `linear-gradient(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.2)),
-      url('${props.imageUrl + THUMBNAIL_SIZE_OPTION}')`,
+      url('${props.imageUrl}')`,
       }}
     >
       <h1>{props.title}</h1>

--- a/src/components/Trade/Quill/index.tsx
+++ b/src/components/Trade/Quill/index.tsx
@@ -7,6 +7,7 @@ import ToastMessageModal from '@/components/Common/ToastMessageModal';
 import { QueryKeys, restFetcher } from '@/queryClient';
 import { TradeBoardDetailType, TradeBoardForm } from '@/types/Board/tradeType';
 import getImageUrls from '@/utils/Quill/getImageUrls';
+import getNotUsedImageUrl from '@/utils/Quill/getNotUsedImageUrl';
 import { PostHouseAPI } from '@/apis/houses';
 import { deleteFile } from '@/apis/uploadS3';
 import { imageStore } from '@/store/imageStore';
@@ -75,7 +76,7 @@ export default function TradeQuill({
   const onPost = async ({ isTempSave }: { isTempSave: boolean }) => {
     setIsProcessing(true);
     const imageUrls = [thumbnail, ...getImageUrls(form.code)];
-    const notUsedImageUrls = images.filter((url) => !imageUrls.includes(url));
+    const notUsedImageUrls = getNotUsedImageUrl(images, imageUrls);
 
     const extractedYear = form.createdDate.match(/\d{4}/);
     const createdDate = extractedYear ? extractedYear[0] : '';
@@ -120,7 +121,7 @@ export default function TradeQuill({
 
   const onUpdate = async ({ isTempSave }: { isTempSave: boolean }) => {
     const imageUrls = [thumbnail, ...getImageUrls(form.code)];
-    const notUsedImageUrls = images.filter((url) => !imageUrls.includes(url));
+    const notUsedImageUrls = getNotUsedImageUrl(images, imageUrls);
     const extractedYear = form.createdDate.match(/\d{4}/);
     const createdDate = extractedYear ? extractedYear[0] : '2002';
 

--- a/src/hooks/useQuillModules.ts
+++ b/src/hooks/useQuillModules.ts
@@ -12,6 +12,7 @@ Quill.register('modules/imageResize', ImageResize);
 
 const useQuillModules = (
   QuillRef: React.MutableRefObject<ReactQuill | undefined>,
+  setImages: (imageUrl: string) => void,
 ) => {
   const modules = useMemo(
     () => ({
@@ -80,7 +81,7 @@ const useQuillModules = (
           ['image'],
           ['clean'],
         ],
-        handlers: { image: () => imageHandler(QuillRef) },
+        handlers: { image: () => imageHandler(QuillRef, setImages) },
       },
     }),
     [],

--- a/src/pages/Community/Detail/index.tsx
+++ b/src/pages/Community/Detail/index.tsx
@@ -19,7 +19,6 @@ export default function CommunityBoardDetailPage() {
   const { user } = userStore();
   const { category, id } = useParams();
   const navigate = useNavigate();
-
   const queryClient = useQueryClient();
   const { data: boardData, isError } = useQuery<
     ApiResponseWithDataType<CommunityBoardDetailType>

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -14,7 +14,6 @@ import { CommunityBoardType } from '@/types/Board/communityType';
 import { IntroBoardType } from '@/types/Board/introType';
 import { getPrefixCategoryName } from '@/utils/utils';
 import { ApiResponseWithDataType } from '@/types/apiResponseType';
-import { THUMBNAIL_SIZE_OPTION } from '@/constants/image';
 import { jumbotronData } from '@/constants/main_dummy';
 import { opacityVariants } from '@/constants/variants';
 import styles from './styles.module.scss';
@@ -181,7 +180,8 @@ export default function MainPage() {
                 </div>
                 <img
                   className={styles.odoiIntro_slide_image}
-                  src={data.imageUrl + THUMBNAIL_SIZE_OPTION}
+                  // src={data.imageUrl + THUMBNAIL_SIZE_OPTION}
+                  src={data.imageUrl}
                   alt="ThumbnailImage"
                 />
               </div>
@@ -223,9 +223,13 @@ export default function MainPage() {
                 <div
                   role="presentation"
                   className={styles.odoiCommunity}
+                  //   style={{
+                  //     backgroundImage: `linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.35)),
+                  // url(${data.imageUrl + THUMBNAIL_SIZE_OPTION})`,
+                  //   }}
                   style={{
                     backgroundImage: `linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.35)),
-                url(${data.imageUrl + THUMBNAIL_SIZE_OPTION})`,
+                url(${data.imageUrl})`,
                   }}
                   onClick={() => {
                     navigate(

--- a/src/pages/Trade/Write/index.tsx
+++ b/src/pages/Trade/Write/index.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 import { FiSearch } from 'react-icons/fi';
 import { MdUploadFile } from 'react-icons/md';
@@ -12,6 +12,7 @@ import {
   TradeBoardForm,
 } from '@/types/Board/tradeType';
 import { uploadFile } from '@/apis/uploadS3';
+import { imageStore } from '@/store/imageStore';
 import userStore from '@/store/userStore';
 import { getRentalPriceType } from '@/utils/utils';
 // import { DEFAULT_OPTIONS } from '@/constants/image';
@@ -24,6 +25,7 @@ const { VITE_S3_DOMAIN } = import.meta.env;
 
 export default function TradeWritePage() {
   const { user } = userStore();
+  const { setImages, resetImages } = imageStore();
 
   const { state }: { state: { data: TradeBoardDetailType } } = useLocation();
 
@@ -81,12 +83,17 @@ export default function TradeWritePage() {
         // const imageUrl = VITE_CLOUD_FRONT_DOMAIN + imageName + DEFAULT_OPTIONS;
         const imageUrl = VITE_S3_DOMAIN + imageName;
         setThumbnail(imageUrl);
+        setImages(imageUrl);
       } catch (error) {
         const err = error as AxiosError;
         return { ...err.response, success: false };
       }
     }
   };
+
+  useEffect(() => {
+    return () => resetImages();
+  }, []);
 
   if (!user) return <Navigate to="/login" />;
 

--- a/src/pages/Trade/Write/index.tsx
+++ b/src/pages/Trade/Write/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 import { FiSearch } from 'react-icons/fi';
 import { MdUploadFile } from 'react-icons/md';
@@ -11,7 +11,7 @@ import {
   TradeBoardDetailType,
   TradeBoardForm,
 } from '@/types/Board/tradeType';
-import { deleteFile, uploadFile } from '@/apis/uploadS3';
+import { uploadFile } from '@/apis/uploadS3';
 import { imageStore } from '@/store/imageStore';
 import userStore from '@/store/userStore';
 import { getRentalPriceType } from '@/utils/utils';
@@ -25,7 +25,7 @@ const { VITE_S3_DOMAIN } = import.meta.env;
 
 export default function TradeWritePage() {
   const { user } = userStore();
-  const { images, setImages, resetImages } = imageStore();
+  const { setImages } = imageStore();
 
   const { state }: { state: { data: TradeBoardDetailType } } = useLocation();
 
@@ -56,7 +56,6 @@ export default function TradeWritePage() {
     state ? state.data.imageUrls[0].split('/')[3] : '',
   );
 
-  const imagesRef = useRef(images);
   const thumbnailRef = useRef<HTMLInputElement>(null);
   // 매물특징
   const [isPostcodeOpen, setIsPostcodeOpen] = useState(false);
@@ -92,17 +91,6 @@ export default function TradeWritePage() {
       }
     }
   };
-
-  useEffect(() => {
-    imagesRef.current = images;
-  }, [images]);
-
-  useEffect(() => {
-    return () => {
-      deleteFile(imagesRef.current);
-      resetImages();
-    };
-  }, []);
 
   if (!user) return <Navigate to="/login" />;
 

--- a/src/pages/Trade/Write/index.tsx
+++ b/src/pages/Trade/Write/index.tsx
@@ -11,7 +11,7 @@ import {
   TradeBoardDetailType,
   TradeBoardForm,
 } from '@/types/Board/tradeType';
-import { uploadFile } from '@/apis/uploadS3';
+import { deleteFile, uploadFile } from '@/apis/uploadS3';
 import { imageStore } from '@/store/imageStore';
 import userStore from '@/store/userStore';
 import { getRentalPriceType } from '@/utils/utils';
@@ -25,7 +25,7 @@ const { VITE_S3_DOMAIN } = import.meta.env;
 
 export default function TradeWritePage() {
   const { user } = userStore();
-  const { setImages, resetImages } = imageStore();
+  const { images, setImages, resetImages } = imageStore();
 
   const { state }: { state: { data: TradeBoardDetailType } } = useLocation();
 
@@ -55,6 +55,8 @@ export default function TradeWritePage() {
   const [thumbnailTitle, setThumbnailTitle] = useState(
     state ? state.data.imageUrls[0].split('/')[3] : '',
   );
+
+  const imagesRef = useRef(images);
   const thumbnailRef = useRef<HTMLInputElement>(null);
   // 매물특징
   const [isPostcodeOpen, setIsPostcodeOpen] = useState(false);
@@ -92,7 +94,14 @@ export default function TradeWritePage() {
   };
 
   useEffect(() => {
-    return () => resetImages();
+    imagesRef.current = images;
+  }, [images]);
+
+  useEffect(() => {
+    return () => {
+      deleteFile(imagesRef.current);
+      resetImages();
+    };
   }, []);
 
   if (!user) return <Navigate to="/login" />;

--- a/src/store/imageStore.ts
+++ b/src/store/imageStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+export type ImageStore = {
+  images: string[];
+  setImages: (imageUrl: string) => void;
+  resetImages: () => void;
+};
+
+export const imageStore = create<ImageStore>((set, get) => ({
+  images: [],
+  setImages: (imageUrl: string) => set({ images: [...get().images, imageUrl] }),
+  resetImages: () => set({ images: [] }),
+}));

--- a/src/utils/Quill/getNotUsedImageUrl.ts
+++ b/src/utils/Quill/getNotUsedImageUrl.ts
@@ -1,0 +1,5 @@
+const getNotUsedImageUrl = (origin: string[], final: string[]) => {
+  return origin.filter((url) => !final.includes(url));
+};
+
+export default getNotUsedImageUrl;

--- a/src/utils/Quill/imageHandler.ts
+++ b/src/utils/Quill/imageHandler.ts
@@ -9,7 +9,9 @@ const { VITE_S3_DOMAIN } = import.meta.env;
 
 const imageHandler = (
   QuillRef: React.MutableRefObject<ReactQuill | undefined>,
+  setImages: (imageUrl: string) => void,
 ) => {
+  // const { setImages } = imageStore();
   const input = document.createElement('input');
 
   input.setAttribute('type', 'file');
@@ -25,6 +27,8 @@ const imageHandler = (
         const imageName = url.split(VITE_S3_DOMAIN)[1];
         // const imageUrl = VITE_CLOUD_FRONT_DOMAIN + imageName + DEFAULT_OPTIONS;
         const imageUrl = VITE_S3_DOMAIN + imageName;
+
+        setImages(imageUrl);
 
         const range = QuillRef.current?.getEditor().getSelection()?.index;
         if (range !== null && range !== undefined) {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -108,7 +108,7 @@ export const getMoveInType = (isCompleted: boolean) => {
 export const checkBeforePost = (
   title: string,
   contents: string,
-  imageUrl?: string[],
+  thumbnail?: string,
 ) => {
   if (title === '') {
     alert('제목을 입력해주세요.');
@@ -118,7 +118,7 @@ export const checkBeforePost = (
     alert('내용을 입력해주세요.');
     return false;
   }
-  if (imageUrl && imageUrl[0] === '') {
+  if (thumbnail === '') {
     alert('썸네일을 등록해주세요.');
     return false;
   }


### PR DESCRIPTION
## 📖 개요
게시글 작성 중 페이지 이탈 시 업로드된 이미지를 S3에서 삭제합니다.
게시글 업로드 시 실제로 사용되는 이미지를 제외하고 에디터에서 지웠던 이미지에 대해 S3에서 삭제합니다.
기존에 적용했던 CloudFront 관련 코드를 제거합니다.

## 💻 작업사항

- 게시글 작성 시 업로드한 이미지의 URL을 저장하는 imageStore 전역 변수를 선언했습니다.
- 게시글 업로드 시 imageStore와 작성한 게시글의 이미지를 비교하여 삭제된 이미지들에 대해 S3에서 삭제하도록 했습니다.
- 게시글 작성 중 페이지를 이탈했을 때 게시글에 작성된 이미지들을 S3에서 삭제하도록 했습니다.

## 💡 작성한 이슈 외에 작업한 사항

- 기존에 적용했던 CloudFront 관련 코드를 제거합니다.

## ✔️ 공유 내용
- 이미 업로드된 게시글의 이미지는 사용자가 추후에 게시글 수정이나 게시글 삭제하여도 S3에서 삭제되지 않도록 하였습ㅁ니다.

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
