### PR TITLE
fix: refresh 토큰 만료 시 사용자에게 Alert를 보여주지 않도록 설정합니다.

### DIFF
--- a/src/apis/reissue.ts
+++ b/src/apis/reissue.ts
@@ -1,8 +1,5 @@
-import axios, { AxiosError } from 'axios';
-import {
-  ApiResponseType,
-  ApiResponseWithDataType,
-} from '@/types/apiResponseType';
+import axios from 'axios';
+import { ApiResponseWithDataType } from '@/types/apiResponseType';
 
 export const reissue = async () => {
   try {
@@ -16,6 +13,6 @@ export const reissue = async () => {
     );
     return data;
   } catch (err) {
-    alert((err as AxiosError<ApiResponseType>).response?.data.message);
+    console.error(err);
   }
 };


### PR DESCRIPTION
## 📖 개요
refresh 토큰 만료 시 사용자에게 서버 응답Alert를 보여주지 않도록 설정합니다.

## 💻 작업사항

- refresh 토큰 만료 시 사용자에게 Alert를 보여주지 않도록 catch문 수정

## 💡 작성한 이슈 외에 작업한 사항

-

## ✔️ check list

- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
