### PR TITLE
TradeBoard에 houseType prop이 생김에 따라 props 전달이 되지 않은 컴포넌트 수정

### DIFF
--- a/src/pages/MyPage/home/index.tsx
+++ b/src/pages/MyPage/home/index.tsx
@@ -68,6 +68,7 @@ function MyHomePage() {
               <TradeBoard
                 key={content.houseId}
                 houseId={content.houseId}
+                houseType={content.houseType}
                 rentalType={content.rentalType}
                 city={content.city}
                 price={content.price}

--- a/src/pages/MyPage/trade/scrap/index.tsx
+++ b/src/pages/MyPage/trade/scrap/index.tsx
@@ -69,6 +69,7 @@ function MyScrapPage() {
               <TradeBoard
                 key={content.houseId}
                 houseId={content.houseId}
+                houseType={content.houseType}
                 rentalType={content.rentalType}
                 city={content.city}
                 price={content.price}


### PR DESCRIPTION
## 📖 개요
TradeBoard에 houseType prop이 생김에 따라 props 전달이 되지 않은 컴포넌트 수정

## 💻 작업사항

- 마이페이지에서 TradeBoard 컴포넌트를 사용하는 부분에 houseType prop 추가

## ✔️ check list

- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
