### PR TITLE
[fix] 농가거래 게시글 input값 수정사항

### DIFF
--- a/src/components/Trade/Info/index.tsx
+++ b/src/components/Trade/Info/index.tsx
@@ -36,7 +36,12 @@ function TradeBoardInfo({ info }: TradeBoardInfoProps) {
           면적 <p>{info?.size}㎡</p>
         </div>
         <div>
-          준공연도 <p>{dayjs(info?.createdDate).format('YYYY')}년</p>
+          준공연도{' '}
+          <p>
+            {info?.createdDate
+              ? `${dayjs(info?.createdDate).format('YYYY')}년`
+              : '-'}
+          </p>
         </div>
         <div>
           용도 <p>{info?.purpose}</p>

--- a/src/components/Trade/Quill/index.tsx
+++ b/src/components/Trade/Quill/index.tsx
@@ -83,8 +83,6 @@ export default function TradeQuill({
 
     const newForm: TradeBoardForm = {
       ...form,
-      contact: form.contact.replace(/\-/g, ''),
-      size: form.size.replace(/m2/g, ''),
       createdDate,
       imageUrls,
       tmpYn: isTempSave,
@@ -123,12 +121,10 @@ export default function TradeQuill({
     const imageUrls = [thumbnail, ...getImageUrls(form.code)];
     const notUsedImageUrls = getNotUsedImageUrl(images, imageUrls);
     const extractedYear = form.createdDate.match(/\d{4}/);
-    const createdDate = extractedYear ? extractedYear[0] : '2002';
+    const createdDate = extractedYear ? extractedYear[0] : '';
 
     const newForm: TradeBoardForm = {
       ...form,
-      contact: form.contact.replace(/\-/g, ''),
-      size: form.size.replace(/m2/g, ''),
       createdDate,
       imageUrls,
       tmpYn: isTempSave,

--- a/src/pages/Trade/Write/index.tsx
+++ b/src/pages/Trade/Write/index.tsx
@@ -75,9 +75,27 @@ export default function TradeWritePage() {
     }));
   };
 
-  const onChangeForm = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const onChangeForm = (
+    e: React.ChangeEvent<HTMLInputElement>,
+    numValue?: number,
+  ) => {
     const { name, value } = e.target;
-    setForm((prev) => ({ ...prev, [name]: value }));
+    setForm((prev) => ({ ...prev, [name]: numValue ?? value }));
+  };
+
+  const onChangePoints = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target;
+    let numValue = Number(value.replace(/[^0-9]/g, ''));
+    if (!numValue) numValue = 0;
+    onChangeForm(e, numValue);
+  };
+
+  const addComma = (price: number) => {
+    if (price === 0) return '';
+    const returnString = price
+      ?.toString()
+      .replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+    return returnString;
   };
 
   const thumbnailHandler = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -277,11 +295,10 @@ export default function TradeWritePage() {
             </label>
             <input
               id="임대 가격"
-              type="number"
-              placeholder="만원으로 표기"
+              placeholder="만원 단위로 표기"
               name="price"
-              value={form.price}
-              onChange={onChangeForm}
+              value={addComma(form.price) || ''}
+              onChange={onChangePoints}
             />
           </div>
           <div
@@ -289,14 +306,15 @@ export default function TradeWritePage() {
               display: form.rentalType === 'MONTHLYRENT' ? '' : 'none',
             }}
           >
-            <label htmlFor="월세">월세</label>
+            <label htmlFor="월세">
+              월세<span className={styles.essential}>*</span>
+            </label>
             <input
               id="월세"
-              type="number"
-              placeholder="만원으로 표기"
+              placeholder="만원 단위로 표기"
               name="monthlyPrice"
-              value={form.monthlyPrice}
-              onChange={onChangeForm}
+              value={addComma(form.monthlyPrice) || ''}
+              onChange={onChangePoints}
             />
           </div>
           <div>

--- a/src/pages/Trade/Write/index.tsx
+++ b/src/pages/Trade/Write/index.tsx
@@ -90,6 +90,12 @@ export default function TradeWritePage() {
     onChangeForm(e, numValue);
   };
 
+  const onParsingPhoneNumber = (phoneNum: string) => {
+    return phoneNum
+      .replace(/[^0-9]/g, '')
+      .replace(/^(\d{2,3})(\d{3,4})(\d{4})$/, `$1-$2-$3`);
+  };
+
   const addComma = (price: number) => {
     if (price === 0) return '';
     const returnString = price
@@ -324,10 +330,19 @@ export default function TradeWritePage() {
             <input
               id="전화번호"
               type="text"
-              placeholder="01000000000 표기(매물 관련 연락 가능한 연락처)"
+              placeholder="매물 관련 연락 가능한 연락처"
               name="contact"
               value={form.contact}
-              onChange={onChangeForm}
+              onChange={(event) =>
+                onChangeForm({
+                  ...event,
+                  target: {
+                    ...event.target,
+                    name: 'contact',
+                    value: onParsingPhoneNumber(event.target.value),
+                  },
+                })
+              }
             />
           </div>
           {user?.userType === 'AGENT' && (

--- a/src/pages/Trade/Write/index.tsx
+++ b/src/pages/Trade/Write/index.tsx
@@ -96,6 +96,13 @@ export default function TradeWritePage() {
       .replace(/^(\d{2,3})(\d{3,4})(\d{4})$/, `$1-$2-$3`);
   };
 
+  const onParsingDecimal = (decimal: string) => {
+    return decimal
+      .replace(/[^0-9.]/g, '')
+      .replace(/^0+(?!\.)/, '')
+      .replace(/(\.\d{2})\d*/, '$1');
+  };
+
   const addComma = (price: number) => {
     if (price === 0) return '';
     const returnString = price
@@ -388,10 +395,19 @@ export default function TradeWritePage() {
             <input
               id="매물 면적"
               type="text"
-              placeholder="㎡로 표기"
+              placeholder="㎡ 단위로 표기"
               name="size"
               value={form.size}
-              onChange={onChangeForm}
+              onChange={(event) =>
+                onChangeForm({
+                  ...event,
+                  target: {
+                    ...event.target,
+                    name: 'size',
+                    value: onParsingDecimal(event.target.value),
+                  },
+                })
+              }
             />
           </div>
           <div>

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -149,7 +149,6 @@ export const checkBeforeTradePost = (
     imageUrls,
     city,
     zipCode,
-    detail,
     price,
     monthlyPrice,
     contact,
@@ -171,10 +170,6 @@ export const checkBeforeTradePost = (
   }
   if (zipCode === '') {
     alert('우편번호를 입력해주세요.');
-    return false;
-  }
-  if (detail === '') {
-    alert('상세주소를 입력해주세요.');
     return false;
   }
   if (price === 0) {


### PR DESCRIPTION
## 📖 개요

1. 임대/매매 월세 가격의 default값이 0으로 되어있는 부분 수정
2. 전화번호 입력란에서 자동으로 하이픈 생성하도록 수정
3. 매물 면적 소수점도 입력 가능하도록 수정
4. 상세 주소 필수 삭제
5. 준공년도가 Invalid Date로 나타나는 이슈

## 💻 작업사항

- [임대/매매 월세 가격의 default값이 0으로 되어있는 부분 수정]
  - input의 타입을 number에서 text로 변경
  - input value에 천 단위로 자동으로 콤마를 생성해주는 `addComma`함수 적용
  - 실제 값에는 콤마가 제외되어야 하므로 input의 onChange에 콤마를 제외해주는 `onChangePoints`함수 적용
  - 실제로는 숫자만 form에 저장됨
- [전화번호 입력란에서 자동으로 하이픈 생성하도록 수정]
  - 전화번호 입력 시 자동으로 하이픈 입력되도록 onParsingPhoneNumber 함수 적용
  - onChaneForm에 전달하는 event target value에 하이픈이 적용된 값으로 전달하도록 수정
- [매물 면적 소수점도 입력 가능하도록 수정]
  - 소수점 둘째자리 숫자만 저장되게 하는 onParsingDecimal 함수 적용
- [상세 주소 필수 삭제]
  - `checkBeforeTradePost` 유틸함수에서 상세 주소 필드 삭제
- [준공년도가 Invalid Date로 나타나는 이슈]
  - 준공년도가 undefined일 경우 -로 표기되도록 수정

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?