### PR TITLE
[fix] 농가거래 게시물 등록 시, 매물 용도는 선택값으로 수정

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -156,7 +156,6 @@ export const checkBeforeTradePost = (
     agentName,
     agentDetail,
     size,
-    purpose,
     title,
     code,
   } = tradeBoardForm;
@@ -208,10 +207,6 @@ export const checkBeforeTradePost = (
     return false;
   }
 
-  if (purpose === '') {
-    alert('용도를 입력해주세요.');
-    return false;
-  }
   if (title === '') {
     alert('제목을 입력해주세요.');
     return false;


### PR DESCRIPTION

## 💻 작업사항

- 농가거래 글쓰기 유효성 검사에서 '매물 용도' 제외

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
