### PR TITLE
[fix] 마이페이지 매물 상태 변경 모달 수정 및 전화번호 포맷 통일

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -1,6 +1,14 @@
-import { lazy } from 'react';
 import { RouteObject } from 'react-router-dom';
 import GlobalLayout from '@/pages/_layout';
+import CommunityPage from './pages/Community';
+import CommunityBoardPage from './pages/Community/Board';
+import CommunityBoardDetailPage from './pages/Community/Detail';
+import CommunityWritePage from './pages/Community/Write';
+import IntroducePage from './pages/Introduce';
+import IntroBoardPage from './pages/Introduce/Board';
+import IntroWritePage from './pages/Introduce/Write';
+import LoginPage from './pages/Login';
+import MainPage from './pages/Main';
 import MyPage from './pages/MyPage';
 import MyCommentsPage from './pages/MyPage/community/comments';
 import MyLikesPage from './pages/MyPage/community/likes';
@@ -14,24 +22,15 @@ import WithdrawalFromMembership from './pages/MyPage/setting/WithdrawalFromMembe
 import MySelfPage from './pages/MyPage/trade/myself';
 import MySavesPage from './pages/MyPage/trade/saves';
 import MyScrapPage from './pages/MyPage/trade/scrap';
+import NotFoundPage from './pages/NotFound';
+import SignUpPage from './pages/SignUp';
+import AgentSignUpPage from './pages/SignUp/AgentSignUp';
+import TradePage from './pages/Trade';
+import TradeBoardPage from './pages/Trade/Board';
+import TradeProcessPage from './pages/Trade/Process';
+import TradeWritePage from './pages/Trade/Write';
+import TradeLayoutPage from './pages/Trade/_layout';
 
-const MainPage = lazy(() => import('@/pages/Main'));
-const LoginPage = lazy(() => import('@/pages/Login'));
-const SignUpPage = lazy(() => import('@/pages/SignUp'));
-const AgentSignUpPage = lazy(() => import('@/pages/SignUp/AgentSignUp'));
-const IntroducePage = lazy(() => import('@/pages/Introduce'));
-const IntroWritePage = lazy(() => import('@/pages/Introduce/Write'));
-const IntroBoardPage = lazy(() => import('@/pages/Introduce/Board'));
-const CommunityPage = lazy(() => import('@/pages/Community'));
-const CommunityBoardPage = lazy(() => import('@/pages/Community/Board'));
-const CommunityBoardDetailPage = lazy(() => import('@/pages/Community/Detail'));
-const CommunityWritePage = lazy(() => import('@/pages/Community/Write'));
-const TradeLayoutPage = lazy(() => import('@/pages/Trade/_layout'));
-const TradePage = lazy(() => import('@/pages/Trade'));
-const TradeBoardPage = lazy(() => import('@/pages/Trade/Board'));
-const TradeWritePage = lazy(() => import('@/pages/Trade/Write'));
-const TradeProcessPage = lazy(() => import('@/pages/Trade/Process'));
-const NotFoundPage = lazy(() => import('@/pages/NotFound'));
 export const routes: RouteObject[] = [
   {
     path: '/',

--- a/src/components/Common/ui/Button/styles.module.scss
+++ b/src/components/Common/ui/Button/styles.module.scss
@@ -3,6 +3,7 @@
   border-width: 1px;
   width: 5.624rem;
   height: 2.5rem;
+  font-size: 1rem;
   border-radius: 4px;
   outline: none;
   cursor: pointer;

--- a/src/components/MyPage/DealStateModal/index.tsx
+++ b/src/components/MyPage/DealStateModal/index.tsx
@@ -11,6 +11,7 @@ import { QueryKeys } from '@/queryClient';
 import { HouseStatusType } from '@/types/Board/myPageType';
 import { PutHouseStatusAPI } from '@/apis/houses';
 import useInput from '@/hooks/useInput';
+import { onParsingPhoneNumber } from '@/utils/utils';
 import { DropdownVariants } from '@/constants/variants';
 import styles from './styles.module.scss';
 
@@ -27,7 +28,7 @@ export default function DealStateModal({
 }: DealStateModalProps) {
   const queryClient = useQueryClient();
 
-  const [contact, handleContact] = useInput('');
+  const [contact, setContact] = useState('');
   const [review, setReview] = useInput('');
   const [nickName, setNickName] = useInput('');
 
@@ -49,6 +50,11 @@ export default function DealStateModal({
   };
   const handleToggleAgeDropdown = () => {
     setIsAgeDropdownOpen(!isAgeDropdownOpen);
+  };
+
+  const handleContactChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const formattedValue = onParsingPhoneNumber(e.target.value);
+    setContact(formattedValue);
   };
 
   const handleDateChange = (date: ValuePiece) => {
@@ -80,7 +86,7 @@ export default function DealStateModal({
       alert('필수 항목을 입력해주세요.');
       return;
     }
-    if (!contact.match(/^(\d{2,3}\d{3,4}\d{4})$/g)) {
+    if (!contact.match(/^\d{2,3}-\d{3,4}-\d{4}$/g)) {
       alert('전화번호 형식이 맞지 않습니다.');
       return;
     }
@@ -151,9 +157,9 @@ export default function DealStateModal({
               <input
                 className={styles.inputStyle}
                 type="text"
-                placeholder={`'-'없이 기재`}
+                placeholder="전화번호 입력"
                 value={contact}
-                onChange={handleContact}
+                onChange={handleContactChange}
               />
               <label htmlFor="">구매자 주말내집 닉네임</label>
               <input

--- a/src/components/MyPage/DealStateModal/index.tsx
+++ b/src/components/MyPage/DealStateModal/index.tsx
@@ -138,6 +138,7 @@ export default function DealStateModal({
                 {isCalendarOpen && (
                   <div className={styles.calendarWrapper}>
                     <Calendar
+                      maxDate={new Date()}
                       onChange={handleDateChange}
                       value={selectedDate}
                     />

--- a/src/components/MyPage/MyTradeCard/index.tsx
+++ b/src/components/MyPage/MyTradeCard/index.tsx
@@ -49,7 +49,7 @@ export default function MyTradeCard({
     >
       <td>{getRentalName(rentalType)}</td>
       <td>
-        <img className={styles.image} src={imageUrl} alt="tradeImage" />
+        <img className={styles.image} src={imageUrl} alt="-" />
       </td>
       <td>{title}</td>
       <td>{city}</td>

--- a/src/pages/MyPage/trade/myself/index.tsx
+++ b/src/pages/MyPage/trade/myself/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import Loading from '@/components/Common/Loading';
 import NoPosts from '@/components/Common/NoPosts';
@@ -37,12 +37,21 @@ export default function MySelfPage() {
     ApiResponseWithDataType<BoardPageType<MyTradeHouseType> & { count: Count }>
   >([QueryKeys.MY_HOUSES, currentPage], () => fetchMyHouseList(currentPage));
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
+  const resetSearch = () => {
     refetch();
     setCurrentPage(1);
     setSearch('');
   };
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    resetSearch();
+  };
+
+  useEffect(() => {
+    resetSearch();
+  }, []);
+
   return (
     <section className={styles.container}>
       {modal && (

--- a/src/pages/SignUp/AgentSignUp/index.tsx
+++ b/src/pages/SignUp/AgentSignUp/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { Controller, useForm } from 'react-hook-form';
 import { Navigate, useNavigate } from 'react-router-dom';
 import { useMutation } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
@@ -16,6 +16,7 @@ import userStore from '@/store/userStore';
 import useCheckAPI from '@/hooks/useCheckAPI';
 import useModalState from '@/hooks/useModalState';
 import useToastMessageType from '@/hooks/useToastMessageType';
+import { onParsingPhoneNumber } from '@/utils/utils';
 import { ApiResponseType } from '@/types/apiResponseType';
 import { TermType } from '@/types/signUp';
 import { opacityVariants } from '@/constants/variants';
@@ -100,6 +101,7 @@ export default function AgentSignUpPage() {
     watch,
     handleSubmit,
     setValue,
+    control,
     formState: { errors },
   } = useForm<IForm>({
     mode: 'onSubmit',
@@ -218,8 +220,10 @@ export default function AgentSignUpPage() {
     else setEyeCheckState((prev) => !prev);
   };
   const onSendSMS = () => {
-    if (/^01(?:0|1|[6-9])[0-9]{7,8}$/g.test(watch('phone_num')) === false)
-      return;
+    const phoneNumber = watch('phone_num').replace(/-/g, ''); // '-' 제거
+
+    if (!/^01(?:0|1|[6-9])[0-9]{7,8}$/g.test(phoneNumber)) return;
+
     phoneSMSAPI(watch('phone_num'), {
       onSuccess: (res) => {
         if (!res) throw Error;
@@ -522,18 +526,32 @@ export default function AgentSignUpPage() {
             공인중개사 사무소 대표 전화번호
           </label>
           <div className={signUpStyles.inputInline}>
-            <input
-              className={signUpStyles.inputStyle}
-              id="company_phone_num"
-              type="text"
-              placeholder="지역번호까지 입력 예) 02, 031"
-              {...register('company_phone_num', {
-                required: '비밀번호는 필수 입력입니다.',
+            <Controller
+              name="company_phone_num"
+              control={control}
+              defaultValue=""
+              rules={{
+                required: '전화번호를 입력해주세요.',
                 pattern: {
-                  value: /^\d{9,11}$/g,
-                  message: `'-' 제외한 유효한 번호를 입력해주세요.`,
+                  value: /^\d{2,3}-\d{3,4}-\d{4}$/,
+                  message: '유효한 전화번호 형식이 아닙니다.',
                 },
-              })}
+              }}
+              render={({ field }) => (
+                <input
+                  className={signUpStyles.inputStyle}
+                  id="company_phone_num"
+                  type="text"
+                  placeholder="지역번호까지 입력 예) 02, 031"
+                  value={field.value}
+                  onChange={(e) => {
+                    const formattedValue = onParsingPhoneNumber(e.target.value);
+                    setValue('company_phone_num', formattedValue, {
+                      shouldValidate: true,
+                    });
+                  }}
+                />
+              )}
             />
           </div>
           <p className={signUpStyles.errorMessage}>
@@ -862,30 +880,44 @@ export default function AgentSignUpPage() {
         <div className={signUpStyles.inputContainer}>
           <label htmlFor="phone_num">휴대폰</label>
           <div className={signUpStyles.inputInline}>
-            <input
-              className={signUpStyles.inputStyle}
-              id="phone_num"
-              type="text"
-              placeholder="‘-’빼고 숫자만 입력"
-              {...register('phone_num', {
+            <Controller
+              name="phone_num"
+              control={control}
+              defaultValue=""
+              rules={{
                 required: '전화번호를 입력해주세요.',
                 pattern: {
-                  value: /^01(?:0|1|[6-9])[0-9]{7,8}$/g,
-                  message: '‘-’빼고 숫자만 입력해주세요.',
+                  value: /^\d{2,3}-\d{3,4}-\d{4}$/,
+                  message: '유효한 전화번호 형식이 아닙니다.',
                 },
-              })}
+              }}
+              render={({ field }) => (
+                <input
+                  className={signUpStyles.inputStyle}
+                  id="phone_num"
+                  type="text"
+                  placeholder="전화번호 입력"
+                  value={field.value}
+                  onChange={(e) => {
+                    const formattedValue = onParsingPhoneNumber(e.target.value);
+                    setValue('phone_num', formattedValue, {
+                      shouldValidate: true,
+                    });
+                  }}
+                />
+              )}
             />
             <button
               type="button"
               className={
-                /^01(?:0|1|[6-9])[0-9]{7,8}$/g.test(watch('phone_num')) &&
+                /^\d{2,3}-\d{3,4}-\d{4}$/.test(watch('phone_num')) &&
                 !isCheckNum
                   ? signUpStyles.buttonStyleActive
                   : signUpStyles.buttonStyle
               }
               onClick={onSendSMS}
               disabled={
-                !/^01(?:0|1|[6-9])[0-9]{7,8}$/g.test(watch('phone_num')) ||
+                !/^\d{2,3}-\d{3,4}-\d{4}$/.test(watch('phone_num')) ||
                 isCheckNum
               }
             >

--- a/src/pages/SignUp/index.tsx
+++ b/src/pages/SignUp/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { Controller, useForm } from 'react-hook-form';
 import { Navigate, useNavigate } from 'react-router-dom';
 import { useMutation } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
@@ -15,6 +15,7 @@ import userStore from '@/store/userStore';
 import useCheckAPI from '@/hooks/useCheckAPI';
 import useModalState from '@/hooks/useModalState';
 import useToastMessageType from '@/hooks/useToastMessageType';
+import { onParsingPhoneNumber } from '@/utils/utils';
 import { ApiResponseType } from '@/types/apiResponseType';
 import { TermType } from '@/types/signUp';
 import { opacityVariants } from '@/constants/variants';
@@ -76,6 +77,7 @@ export default function SignUpPage() {
     watch,
     handleSubmit,
     setValue,
+    control,
     formState: { errors },
   } = useForm<IForm>({
     mode: 'onSubmit',
@@ -183,8 +185,10 @@ export default function SignUpPage() {
     else setEyeCheckState((prev) => !prev);
   };
   const onSendSMS = () => {
-    if (/^01(?:0|1|[6-9])[0-9]{7,8}$/g.test(watch('phone_num')) === false)
-      return;
+    const phoneNumber = watch('phone_num').replace(/-/g, ''); // '-' 제거
+
+    if (!/^01(?:0|1|[6-9])[0-9]{7,8}$/g.test(phoneNumber)) return;
+
     phoneSMSAPI(watch('phone_num'), {
       onSuccess: (res) => {
         if (!res) throw Error;
@@ -512,30 +516,44 @@ export default function SignUpPage() {
         <div className={styles.inputContainer}>
           <label htmlFor="phone_num">휴대폰</label>
           <div className={styles.inputInline}>
-            <input
-              className={styles.inputStyle}
-              id="phone_num"
-              type="text"
-              placeholder="‘-’빼고 숫자만 입력"
-              {...register('phone_num', {
+            <Controller
+              name="phone_num"
+              control={control}
+              defaultValue=""
+              rules={{
                 required: '전화번호를 입력해주세요.',
                 pattern: {
-                  value: /^01(?:0|1|[6-9])[0-9]{7,8}$/g,
-                  message: '‘-’빼고 숫자만 입력해주세요.',
+                  value: /^\d{2,3}-\d{3,4}-\d{4}$/,
+                  message: '유효한 전화번호 형식이 아닙니다.',
                 },
-              })}
+              }}
+              render={({ field }) => (
+                <input
+                  className={styles.inputStyle}
+                  id="phone_num"
+                  type="text"
+                  placeholder="전화번호 입력"
+                  value={field.value}
+                  onChange={(e) => {
+                    const formattedValue = onParsingPhoneNumber(e.target.value);
+                    setValue('phone_num', formattedValue, {
+                      shouldValidate: true,
+                    });
+                  }}
+                />
+              )}
             />
             <button
               type="button"
               className={
-                /^01(?:0|1|[6-9])[0-9]{7,8}$/g.test(watch('phone_num')) &&
+                /^\d{2,3}-\d{3,4}-\d{4}$/.test(watch('phone_num')) &&
                 !isCheckNum
                   ? styles.buttonStyleActive
                   : styles.buttonStyle
               }
               onClick={onSendSMS}
               disabled={
-                !/^01(?:0|1|[6-9])[0-9]{7,8}$/g.test(watch('phone_num')) ||
+                !/^\d{2,3}-\d{3,4}-\d{4}$/.test(watch('phone_num')) ||
                 isCheckNum
               }
             >

--- a/src/pages/Trade/Write/index.tsx
+++ b/src/pages/Trade/Write/index.tsx
@@ -15,7 +15,7 @@ import {
 import { uploadFile } from '@/apis/uploadS3';
 import { imageStore } from '@/store/imageStore';
 import userStore from '@/store/userStore';
-import { getRentalPriceType } from '@/utils/utils';
+import { getRentalPriceType, onParsingPhoneNumber } from '@/utils/utils';
 // import { DEFAULT_OPTIONS } from '@/constants/image';
 import {
   houseCategory,
@@ -88,12 +88,6 @@ export default function TradeWritePage() {
     let numValue = Number(value.replace(/[^0-9]/g, ''));
     if (!numValue) numValue = 0;
     onChangeForm(e, numValue);
-  };
-
-  const onParsingPhoneNumber = (phoneNum: string) => {
-    return phoneNum
-      .replace(/[^0-9]/g, '')
-      .replace(/^(\d{2,3})(\d{3,4})(\d{4})$/, `$1-$2-$3`);
   };
 
   const onParsingDecimal = (decimal: string) => {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -285,3 +285,9 @@ export const isConsonant = (char: string) => {
 export const checkTextString = (text: string) => {
   return [...text].map((v) => isConsonant(v)).some((v) => v === true);
 };
+
+export const onParsingPhoneNumber = (phoneNum: string) => {
+  return phoneNum
+    .replace(/[^0-9]/g, '')
+    .replace(/^(\d{2,3})(\d{3,4})(\d{4})$/, `$1-$2-$3`);
+};


### PR DESCRIPTION
## 📖 개요
마이페이지의 매물 상태 변경 모달의 날짜 선택 범위를 수정합니다.
불필요한 코드 스플리팅을 제거하고 전화번호 입력 포맷을 통일화합니다.

## 💻 작업사항

- 날짜 선택 범위를 현재, 과거만 선택할 수 있도록 maxDate 설정
- 불필요한 코드 스플리팅을 제거하여 페이지 이동 시 로딩 없이 접근하도록 수정
- 회원가입, 공인중개사 회원가입, 매물 상태 변경 시 전화번호 입력 필드의 포맷을 "-"을 자동으로 추가하여 포맷을 입력하도록 유효성 검사 수정 및 입력 자동화

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
